### PR TITLE
CKAN-UI #387 - Change language tags to use "English" and "Francais"

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -74,8 +74,10 @@
                                       </v-list-item>
                                     </span>
                                 </template>
-                                <v-list-item v-if="this.$i18n.locale != 'en'" left fixed color="text" id="mobile-english-btn" @click="setLanguage('en')">{{$tc('Language')}}: English</v-list-item>
-                                <v-list-item v-if="this.$i18n.locale != 'fr'" left fixed color="text" id="mobile-french-btn" @click="setLanguage('fr')">{{$tc('Language')}}: Français</v-list-item>
+                                <v-list-item v-if="this.$i18n.locale != 'en'" left fixed color="text" class="hidden-sm-and-down" id="english-btn" @click="setLanguage('en')">{{$tc('Language')}}: English</v-list-item>
+                                <v-list-item v-if="this.$i18n.locale != 'fr'" left fixed color="text" class="hidden-sm-and-down" id="french-btn" @click="setLanguage('fr')">{{$tc('Language')}}: Français</v-list-item>
+                                <v-list-item v-if="this.$i18n.locale != 'en'" left fixed color="text" class="hidden-md-and-up" id="mobile-english-btn" @click="setLanguage('en')">{{$tc('Language')}}: EN</v-list-item>
+                                <v-list-item v-if="this.$i18n.locale != 'fr'" left fixed color="text" class="hidden-md-and-up" id="mobile-french-btn" @click="setLanguage('fr')">{{$tc('Language')}}: FR</v-list-item>
                                 </v-list>
                             <!-- </v-col>
                         </v-row> -->

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -74,8 +74,8 @@
                                       </v-list-item>
                                     </span>
                                 </template>
-                                <v-list-item v-if="this.$i18n.locale != 'en'" left fixed color="text" id="mobile-english-btn" @click="setLanguage('en')">{{$tc('Language')}}: EN</v-list-item>
-                                <v-list-item v-if="this.$i18n.locale != 'fr'" left fixed color="text" id="mobile-french-btn" @click="setLanguage('fr')">{{$tc('Language')}}: FR</v-list-item>
+                                <v-list-item v-if="this.$i18n.locale != 'en'" left fixed color="text" id="mobile-english-btn" @click="setLanguage('en')">{{$tc('Language')}}: English</v-list-item>
+                                <v-list-item v-if="this.$i18n.locale != 'fr'" left fixed color="text" id="mobile-french-btn" @click="setLanguage('fr')">{{$tc('Language')}}: Français</v-list-item>
                                 </v-list>
                             <!-- </v-col>
                         </v-row> -->


### PR DESCRIPTION
Changed the language tags in the hamburger window to use the terms "English/Francais" rather than "EN/FR".