### PR TITLE
CKAN-UI #387 - Remove "Language" portion of language string

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -74,10 +74,10 @@
                                       </v-list-item>
                                     </span>
                                 </template>
-                                <v-list-item v-if="this.$i18n.locale != 'en'" left fixed color="text" class="hidden-sm-and-down" id="english-btn" @click="setLanguage('en')">{{$tc('Language')}}: English</v-list-item>
-                                <v-list-item v-if="this.$i18n.locale != 'fr'" left fixed color="text" class="hidden-sm-and-down" id="french-btn" @click="setLanguage('fr')">{{$tc('Language')}}: Français</v-list-item>
-                                <v-list-item v-if="this.$i18n.locale != 'en'" left fixed color="text" class="hidden-md-and-up" id="mobile-english-btn" @click="setLanguage('en')">{{$tc('Language')}}: EN</v-list-item>
-                                <v-list-item v-if="this.$i18n.locale != 'fr'" left fixed color="text" class="hidden-md-and-up" id="mobile-french-btn" @click="setLanguage('fr')">{{$tc('Language')}}: FR</v-list-item>
+                                <v-list-item v-if="this.$i18n.locale != 'en'" left fixed color="text" class="hidden-sm-and-down" id="english-btn" @click="setLanguage('en')">English</v-list-item>
+                                <v-list-item v-if="this.$i18n.locale != 'fr'" left fixed color="text" class="hidden-sm-and-down" id="french-btn" @click="setLanguage('fr')">Français</v-list-item>
+                                <v-list-item v-if="this.$i18n.locale != 'en'" left fixed color="text" class="hidden-md-and-up" id="mobile-english-btn" @click="setLanguage('en')">EN</v-list-item>
+                                <v-list-item v-if="this.$i18n.locale != 'fr'" left fixed color="text" class="hidden-md-and-up" id="mobile-french-btn" @click="setLanguage('fr')">FR</v-list-item>
                                 </v-list>
                             <!-- </v-col>
                         </v-row> -->


### PR DESCRIPTION
Rather than using "Language: English/Francais", simply use "English" or "Francais".