### PR TITLE
Added confirmation dialogs for delete actions

### DIFF
--- a/frontend/src/components/dataset/ResourceCard.vue
+++ b/frontend/src/components/dataset/ResourceCard.vue
@@ -73,9 +73,11 @@ export default {
     },
     methods: {
         deleteResource: function(){
-            ckanServ.deleteResource(this.resource.id).then( () => {
-                location.reload();
-            });
+            if (confirm("This will permanently delete this information. Continue?")) {
+                ckanServ.deleteResource(this.resource.id).then( () => {
+                    location.reload();
+                });
+            }
         }
     },
     computed: {

--- a/frontend/src/components/pages/about.vue
+++ b/frontend/src/components/pages/about.vue
@@ -118,7 +118,7 @@
                     if (data.success){
                         this.formSuccess = true;
                         this.formError = false;
-                        this.formMessage = "Succesfully udpated";
+                        this.formMessage = "Succesfully updated";
                         this.editing = false;
                     }else{
                         this.formSuccess = false;

--- a/frontend/src/components/pages/dataset_view.vue
+++ b/frontend/src/components/pages/dataset_view.vue
@@ -502,25 +502,28 @@ export default {
             this.showFormSuccess = false;
         },
         async deleteDataset(){
-            const response = await ckanServ.deleteDataset(this.datasetId);
+            if (confirm("This will permanently delete this information. Continue?")) {
 
-            this.formSuccess = "";
-            this.formError = "";
+                const response = await ckanServ.deleteDataset(this.datasetId);
 
-            if (response.success && response.success === true && (!response.error || response.error === false)){
-                this.formSuccess = "Successfully deleted";
-                this.showFormSuccess = true;
-                this.showFormError = false;
-                return;
-            }else if (response.error){
-                this.formError = response.error;
+                this.formSuccess = "";
+                this.formError = "";
+
+                if (response.success && response.success === true && (!response.error || response.error === false)){
+                    this.formSuccess = "Successfully deleted";
+                    this.showFormSuccess = true;
+                    this.showFormError = false;
+                    return;
+                } else if (response.error){
+                    this.formError = response.error;
+                    this.showFormSuccess = false;
+                    this.showFormError = true;
+                    return;
+                }
+                this.formError = "Unknown error deleting dataset";
                 this.showFormSuccess = false;
                 this.showFormError = true;
-                return;
             }
-            this.formError = "Unknown error deleting dataset";
-            this.showFormSuccess = false;
-            this.showFormError = true;
         },
         cancel(){
             if (this.createMode){


### PR DESCRIPTION
Per issue #448, I've added confirmation dialogs to the remove resource/dataset buttons. This is to reduce the risk of accidental deletions. I also snuck in a typo fix for "Succesfully udpated".

To keep things simple and not introduce too much new code, I'm using the browser's built-in confirmation boxes for now.