### PR TITLE
Fix for failed uploads in issue #457

### DIFF
--- a/frontend/src/components/form/components/Upload.vue
+++ b/frontend/src/components/form/components/Upload.vue
@@ -83,10 +83,12 @@ export default {
         parentObject: Object,
     },
     data() {
+        let isUrl;
+    
         if (typeof(this.currentlyUrl) === "boolean") {
-            var isURL = this.currentlyUrl;
+            isURL = this.currentlyUrl;
         } else {
-            var isURL = (
+            isURL = (
                 typeof(this.currentlyUrl) === "string" &&
                 this.currentlyUrl.toLowerCase() === "true"
             ) || this.field.field_name === "url";

--- a/frontend/src/components/form/components/Upload.vue
+++ b/frontend/src/components/form/components/Upload.vue
@@ -83,7 +83,7 @@ export default {
         parentObject: Object,
     },
     data() {
-        let isUrl;
+        let isURL;
     
         if (typeof(this.currentlyUrl) === "boolean") {
             isURL = this.currentlyUrl;

--- a/frontend/src/components/form/components/Upload.vue
+++ b/frontend/src/components/form/components/Upload.vue
@@ -83,27 +83,22 @@ export default {
         parentObject: Object,
     },
     data() {
-        let iu = (typeof(this.currentlyUrl) === "boolean") ? this.currentlyUrl : null;
-        iu = (typeof(this.currentlyUrl) === "string") ? (this.currentlyUrl.toLowerCase()==='true') : iu;
-        iu = ( (iu === null) && (typeof(this.isURL) !== "undefined") ) ? this.isUrl : iu;
-        iu = ( (iu === null) && (this.field.field_name === "url") ) ? (this.field.field_name === "url"): iu;
-
-        let v = (( (this.field.required) || (this.field.validators && this.field.validators.indexOf('conditional_required')!==-1) ) ? 'required' : '');
-        if (iu) {
-            v = {
-                url: {require_tld: true, require_host: true},
-                required: (v === "required")
-            }
+        if (typeof(this.currentlyUrl) === "boolean") {
+            var isURL = this.currentlyUrl;
+        } else {
+            var isURL = (
+                typeof(this.currentlyUrl) === "string" &&
+                this.currentlyUrl.toLowerCase() === "true"
+            ) || this.field.field_name === "url";
         }
 
         return {
             val: this.value,
             fileVal: (this.upload) ? this.upload : null,
-            validate: v,
             allowURL: this.field.field_name === "url",
-            isURL: iu,
             scopeName: this.scope + '.' + this.name,
             api: null,
+            isURL
         }
     },
     computed: {
@@ -111,6 +106,20 @@ export default {
             let required = ( (this.field.required) || (this.field.validators && this.field.validators.indexOf('conditional_required')!==-1) )
             return this.label + (required ? '*' : '');
         },
+
+        validate: function() {
+
+            let v = (( (this.field.required) || (this.field.validators && this.field.validators.indexOf('conditional_required')!==-1) ) ? 'required' : '');
+
+            if (this.isURL) {
+                v = {
+                    url: {require_tld: true, require_host: true},
+                    required: (v === "required")
+                }
+            }
+
+            return v;
+        }
     },
     watch: {
         value(){


### PR DESCRIPTION
Whenever an attempt is made to overwrite uploaded resources with new files, errors are often triggered behind the scenes. These errors are caused by URL validators being incorrectly applied to file upload objects. The errors are triggered anytime an existing resource has a resource upload type of URL and a new file upload is attempted. The effect is that the upload cannot proceed.

Although there was preexisting logic to vary the validators based on whether a URL or File Upload method is chosen, these only ran when the resource edit page first loaded, which is the time the file upload component first mounted. I have modified the code such that the list of applicable validators changes whenever the upload method changes.