### PR TITLE
Default to ordering search results by relevance instead of date (#509)

### DIFF
--- a/frontend/src/components/dataset/ListPage.vue
+++ b/frontend/src/components/dataset/ListPage.vue
@@ -316,7 +316,10 @@
         this.so = this.$store.state.search.sortOrder;
         let self = this;
         this.$store.subscribe((mutation) => {
-            if (mutation.type.startsWith('search/setSearchText')){
+
+            // mutation could be search/setSearchTextAndRedirect too; we want to subscribe to anything that
+            // updates search text.
+            if (mutation.type.startsWith('search/setSearchText')) {
                 self.findText = this.$store.state.search.searchText;
                 self.getDatasets();
             }

--- a/frontend/src/components/dataset/ListPage.vue
+++ b/frontend/src/components/dataset/ListPage.vue
@@ -316,7 +316,7 @@
         this.so = this.$store.state.search.sortOrder;
         let self = this;
         this.$store.subscribe((mutation) => {
-            if (mutation.type === 'search/setSearchText'){
+            if (mutation.type.startsWith('search/setSearchText')){
                 self.findText = this.$store.state.search.searchText;
                 self.getDatasets();
             }

--- a/frontend/src/components/dataset/ListPage.vue
+++ b/frontend/src/components/dataset/ListPage.vue
@@ -197,7 +197,14 @@
                 this.noResults = false;
             }
 
-            let q = "?rows=" + this.rows+"&sort="+this.sortOrder+"&include_drafts=true&include_private=true&"
+            // if the search is blank, and we're sorting by relevance, actually sort by newest
+            // per bcgov#509
+            let effectiveOrder = this.sortOrder;
+            if (!this.searchText || /^\s+$/.test(this.searchText) && this.sortOrder.startsWith("score")) {
+                effectiveOrder = "metadata_created desc";
+            }
+
+            let q = "?rows=" + this.rows+"&sort="+effectiveOrder+"&include_drafts=true&include_private=true&"
 
             let fq = "&fq="
 

--- a/frontend/src/components/pages/home.vue
+++ b/frontend/src/components/pages/home.vue
@@ -158,11 +158,8 @@
 
       methods:{
         search: function(e){
-            // eslint-disable-next-line no-console
             if (e.keyCode === 13 || e.type === 'click') {
-                this.$store.commit('search/setSearchText', this.searchText );
-                this.$store.commit('search/setClearOnRedirect', false);
-                this.$router.push('/datasets');
+              this.$store.commit('search/setSearchTextAndRedirect', this.searchText);                
             }
         },
         termClick: function(e){

--- a/frontend/src/store/modules/search.js
+++ b/frontend/src/store/modules/search.js
@@ -5,8 +5,7 @@ import router from '../../router/index';
 import { CkanApi } from '../../services/ckanApi';
 const ckanServ = new CkanApi();
 
-const DEFAULT_SORT_NO_TEXT_ORDER = "metadata_created desc";
-const DEFAULT_SORT_WITH_TEXT_ORDER = "score desc";
+const DEFAULT_SORT_ORDER = "score desc";
 
 const state = {
     facets: {},
@@ -14,7 +13,7 @@ const state = {
     searchText: "",
     clearOnRedirect: true,
     landingTerms: [],
-    sortOrder: DEFAULT_SORT_NO_TEXT_ORDER,
+    sortOrder: DEFAULT_SORT_ORDER
 };
 
 const getters = {
@@ -70,7 +69,7 @@ const mutations = {
     setSearchTextAndRedirect(state, text ){
         state.searchText = text;
         state.clearOnRedirect = false;
-        state.sortOrder = DEFAULT_SORT_WITH_TEXT_ORDER;
+        state.sortOrder = DEFAULT_SORT_ORDER;
         router.push('/datasets');
     },
 
@@ -79,7 +78,7 @@ const mutations = {
     },
 
     defaultSortOrder(state){
-        state.sortOrder = (state.searchText === "") ? DEFAULT_SORT_NO_TEXT_ORDER : DEFAULT_SORT_WITH_TEXT_ORDER;
+        state.sortOrder = DEFAULT_SORT_ORDER;
     }
 }
 

--- a/frontend/src/store/modules/search.js
+++ b/frontend/src/store/modules/search.js
@@ -70,7 +70,10 @@ const mutations = {
         state.searchText = text;
         state.clearOnRedirect = false;
         state.sortOrder = DEFAULT_SORT_ORDER;
-        router.push('/datasets');
+
+        if (location.pathname !== "/datasets") {
+            router.push('/datasets');
+        }
     },
 
     setSortOrder(state, sort){


### PR DESCRIPTION
Per bcgov#509, search results are being ordered by date when they should be ordered by relevance. 

1. open an incognito window
2. visit https://beta-catalogue.data.gov.bc.ca
3. perform a search for anything using the search box in the centre of the screen
4. note that the results are ordered newest to oldest and that this order persists for subsequent searches unless manually updated

I've changed the behaviour such that you can:

1. open an incognito window
2. visit https://beta-catalogue.data.gov.bc.ca
3. perform a search for anything using the search box in the centre of the screen
4. **order by relevance will be selected, but if the search string was blank (to show all results) the results will actually be ordered newest to oldest**