### PR TITLE
Added parens to fix precedence issue

### DIFF
--- a/frontend/src/components/dataset/ListPage.vue
+++ b/frontend/src/components/dataset/ListPage.vue
@@ -200,7 +200,7 @@
             // if the search is blank, and we're sorting by relevance, actually sort by newest
             // per bcgov#509
             let effectiveOrder = this.sortOrder;
-            if (!this.searchText || /^\s+$/.test(this.searchText) && this.sortOrder.startsWith("score")) {
+            if ((!this.searchText || /^\s+$/.test(this.searchText)) && this.sortOrder.startsWith("score")) {
                 effectiveOrder = "metadata_created desc";
             }
 


### PR DESCRIPTION
In follow up to my previous pull request, I added parens around the "is a blank string" portion of the effective search order logic so that results aren't sorted by newest for all blank searches; that need only apply if a search is blank AND the preferred order is relevance.