### PR TITLE
Changed colour and content of logout success message

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -116,8 +116,8 @@
                 <v-alert
                   dense
                   dismissible
-                  type="warning">
-                  You have been logged out
+                  type="success">
+                  You're now logged out
                 </v-alert>
               </v-col>
             </v-row>


### PR DESCRIPTION
Per bcgov#425, I've updated the logout success message so that it is green and says "You're now logged out".

It looks like this now:

![image](https://user-images.githubusercontent.com/5297264/128054041-4ccd4764-0dec-475e-8a3e-ea200b6293e6.png)




