### PR TITLE
Removed dataset usage from hamburger menu

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -164,10 +164,10 @@ export default {
             //     "title": "What is DataBC?",
             //     "href": "http://www2.gov.bc.ca/gov/content/governments/about-the-bc-government/databc"
             // },
-            {
-                "title": "Dataset Usage",
-                "link": "/usage"
-            },
+            // {
+            //     "title": "Dataset Usage",
+            //     "link": "/usage"
+            // },
             {
                 "title": "Geographic Services",
                 "href": "https://www2.gov.bc.ca/gov/content/data/geographic-data-services"


### PR DESCRIPTION
Per bcgov#516 and its parent issue, bcgov#377, I've removed Dataset Usage from the hamburger menu.