### PR TITLE
Removed logic to pull from notes field

### DIFF
--- a/frontend/src/components/pages/organization_view.vue
+++ b/frontend/src/components/pages/organization_view.vue
@@ -73,17 +73,7 @@
                                     placeholder="">
                                 </Markdown>
                             </v-row>
-                            <v-row wrap class="py-5" v-else-if="group.notes">
-                                <Markdown
-                                    name="notes"
-                                    :value="group.notes"
-                                    label=""
-                                    :editing="false"
-                                    :field="group.description"
-                                    :disabled="false"
-                                    placeholder="">
-                                </Markdown>
-                            </v-row>
+
                             <v-row class="borderTop">
                                 <MemberList :groupId="group.id" :members="members"></MemberList>
                             </v-row>


### PR DESCRIPTION
This is a cleanup patch to close out bcgov#495. The schema has been updated per PR https://github.com/bcgov/ckanext-bcgov-schema/pull/40, so we can now remove an obsolete code path from the UI. Now, only `description` fields are consulted for organizations and groups, not `notes`. Since the bug in bcgov#495 was already resolved by patching the schema repo, this PR is some final housekeeping which should not affect functionality.