### PR TITLE
Changed deletion confirmation messages for resources and datasets

### DIFF
--- a/frontend/src/components/dataset/ResourceCard.vue
+++ b/frontend/src/components/dataset/ResourceCard.vue
@@ -73,7 +73,7 @@ export default {
     },
     methods: {
         deleteResource: function(){
-            if (confirm("This will permanently delete this information. Continue?")) {
+            if (confirm("Are you sure you want to delete this resource?")) {
                 ckanServ.deleteResource(this.resource.id).then( () => {
                     location.reload();
                 });

--- a/frontend/src/components/pages/dataset_view.vue
+++ b/frontend/src/components/pages/dataset_view.vue
@@ -502,7 +502,7 @@ export default {
             this.showFormSuccess = false;
         },
         async deleteDataset(){
-            if (confirm("This will permanently delete this information. Continue?")) {
+            if (confirm("Are you sure you want to delete this record and all its resources?")) {
 
                 const response = await ckanServ.deleteDataset(this.datasetId);
 

--- a/frontend/src/components/pages/resource.vue
+++ b/frontend/src/components/pages/resource.vue
@@ -432,26 +432,28 @@ export default {
                 this.notAtTop = true;
             }
         },
-        async deleteResource(){
-            const response = await ckanServ.deleteResource(this.resourceId);
+        async deleteResource() {
+            if (confirm("Are you sure you want to delete this resource?")) {
+                const response = await ckanServ.deleteResource(this.resourceId);
 
-            this.formSuccess = "";
-            this.formError = "";
+                this.formSuccess = "";
+                this.formError = "";
 
-            if (response.success && response.success === true && (!response.error || response.error === false)){
-                this.formSuccess = "Successfully deleted";
-                this.showFormSuccess = true;
-                this.showFormError = false;
-                return;
-            }else if (response.error){
-                this.formError = response.error;
+                if (response.success && response.success === true && (!response.error || response.error === false)){
+                    this.formSuccess = "Successfully deleted";
+                    this.showFormSuccess = true;
+                    this.showFormError = false;
+                    return;
+                } else if (response.error){
+                    this.formError = response.error;
+                    this.showFormSuccess = false;
+                    this.showFormError = true;
+                    return;
+                }
+                this.formError = "Unknown error deleting resource";
                 this.showFormSuccess = false;
                 this.showFormError = true;
-                return;
             }
-            this.formError = "Unknown error deleting resource";
-            this.showFormSuccess = false;
-            this.showFormError = true;
         },
         cancel(){
             if (this.createMode){


### PR DESCRIPTION
Per https://github.com/bcgov/ckan-ui/issues/448#issuecomment-892220711, updated deletion confirmation messages for datasets and resources to use unique wording which clearly indicates what will be deleted. Also added the resource delete confirmation dialog in a place it was missed, that being on the  resource pages themselves.

**Dataset deletion confirmation**

![image](https://user-images.githubusercontent.com/5297264/128260414-83cf8a4f-00dd-4d9d-85b9-62b36c24ff1d.png)


**Resource deletion confirmation**

![image](https://user-images.githubusercontent.com/5297264/128261270-bd3f7bd6-ea89-419a-930f-1ddce8b869af.png)
