### PR TITLE
Fix broken organization filtering

### DIFF
--- a/frontend/src/components/pages/organizations.vue
+++ b/frontend/src/components/pages/organizations.vue
@@ -73,7 +73,7 @@
             </v-col>
             
             <v-col cols=11 sm=7 v-else>
-                <OrgTree :top="true" v-for="(org, key) in orgList" :key="'org-tree-'+key" :passedOrg="{key: org, org: orgs[org]}"></OrgTree>
+                <OrgTree :top="true" v-for="(org, key) in orgs" :key="'org-tree-'+key" :passedOrg="{key: key, org }"></OrgTree>
             </v-col>
             <v-col cols=1 sm=1></v-col>
             <v-col cols=4 class="d-none d-sm-block fixed rightZero pr-1 mr-10">


### PR DESCRIPTION
bcgov#498 refers - the list of organizations at https://beta-catalogue.data.gov.bc.ca/organization is not filtered according to the provided keywords. The feature appears to have been designed to return the parent organizations that either included the provided keywords or contained sub-organizations which included the keywords. That is not how it was implemented however. Instead, the first N parent organizations in the global list were returned, where N is the number of matching parent organizations. There is a trivial fix to restore the intended behaviour, implemented here.

There is room for improvement to make the search less naive (it tries to match exact substrings for the entire search term) and also to make it more functional, for example by filtering the suborganizations as well or at least drawing attention to the matching result, but that is out of scope for this ticket.