### PR TITLE
bcgov#489 - hiding download button and url for ofi resources

### DIFF
--- a/frontend/src/components/form/DynamicForm.vue
+++ b/frontend/src/components/form/DynamicForm.vue
@@ -1,7 +1,7 @@
 <template>
     <v-container>
         <v-row v-for="(field, fieldKey) in processedSchema" :key="'field-'+fieldKey+'-'+redrawIndex">
-                <div v-if="field.label !== ''" style="width: 100%;">
+                <div v-if="field.label !== '' && !exclude.includes(field.field_name)" style="width: 100%;">
                     <Title
                         v-if="field.preset==='title' || field.field_name === 'title'"
                         :name="field.field_name"
@@ -380,6 +380,10 @@ export default {
         formDefaults: {
             type: Object,
             default: () => {}
+        },
+        exclude: {
+            type: Array,
+            default: () => []
         }
     },
     data() {

--- a/frontend/src/components/pages/resource.vue
+++ b/frontend/src/components/pages/resource.vue
@@ -96,7 +96,7 @@
                     </v-dialog>
                 </v-btn>
 
-                <v-btn v-if="!editing" small depressed text color="primary" :href="resource.url">
+                <v-btn v-if="!editing && !loadPOW" small depressed text color="primary" :href="resource.url">
                     <v-icon>mdi-download</v-icon>&nbsp;{{$tc('Download')}}
                 </v-btn>
 
@@ -147,6 +147,7 @@
                             :values="resource"
                             :loggedIn="loggedIn"
                             :disabled="disabled"
+                            :exclude="excludedFields"
                             ref="dynoForm"
                             @updated="(field, value) => updateResource(field, value)"
                         >
@@ -257,9 +258,19 @@ export default {
             }
         },
     },
+
     computed: {
         loadPOW: function() {
             return (this.resource.bcdc_type=="geographic" && ("object_name" in this.resource) && this.resource.name.toLowerCase().indexOf("custom download") !== -1);
+        },
+
+
+        excludedFields: function() {
+            if (this.loadPOW && !this.editing) {
+                return ["url"]; // hide the URL field for the non-edit screen of OFI resources
+            } else {
+                return [];
+            }
         },
 
         mailLink(){


### PR DESCRIPTION
Per bcgov#489, I removed a couple of UI elements from the OFI resource screens. These elements include the download button, which is not applicable to geographic warehouse resources, and the URL field. These are hidden in the same conditions as are used to determine whether the OFI/POW "Request Access" button is shown.

To accomplish this, I added a generic field exclusion capability to the DynamicForm component and excluding the URL field according to the value of the loadPOW conditional.

![image](https://user-images.githubusercontent.com/5297264/130292186-b263d3a5-04e8-4b7d-b4bc-d10ff1c8efc1.png)
