### PR TITLE
bcgov#494 - hide filesize if 0

### DIFF
--- a/frontend/src/components/dataset/ResourceCard.vue
+++ b/frontend/src/components/dataset/ResourceCard.vue
@@ -19,7 +19,7 @@
                         <label left class="sublabel">
                             {{useResource.metadata.format}}
                         </label>
-                        <span v-if="useResource.metadata.size" class="sublabel ml-4">
+                        <span v-if="useResource.metadata.size && useResource.metadata.size > 0" class="sublabel ml-4">
                             {{(useResource.metadata.size/1000).toFixed(1)}} MB
                         </span>
                     </span>


### PR DESCRIPTION
Per bcgov#494, hiding file sizes from resource cards if they're 0.0 MB. Simple logical change to account for the fact that file sizes are expressed as numeric strings like '0'.