### PR TITLE
Updated button wording for accessing or downloading resources

### DIFF
--- a/frontend/src/components/dataset/ResourceCard.vue
+++ b/frontend/src/components/dataset/ResourceCard.vue
@@ -25,12 +25,12 @@
                     </span>
                     <span class="floatRight">
                         <v-btn v-if="!loadPOW" class="px-0" small depressed text :href="useResource.metadata.url" color="label_colour">
-                            Access/Download
+                            {{$tc("Access/Download")}}&nbsp;
                         </v-btn>
                         <powButton v-else :btn="true" :resource="useResource.metadata"/>
                         <v-btn v-if="!datasetBeingEdited" small depressed text class="px-0" color="label_colour"
                                 :to="{ name: 'resource_view', params: { datasetId: dataset.name, resourceId: resource.id}}">
-                            View
+                            {{$tc("View")}}
                         </v-btn>
                         <v-btn v-if="!!useResource.hasSchema" small depressed text class="px-0" @click.stop="schemaDialog = true" color="label_colour">
                             View Schema (JSON Table Schema)

--- a/frontend/src/components/dataset/ResourceCard.vue
+++ b/frontend/src/components/dataset/ResourceCard.vue
@@ -25,7 +25,7 @@
                     </span>
                     <span class="floatRight">
                         <v-btn v-if="!loadPOW" class="px-0" small depressed text :href="useResource.metadata.url" color="label_colour">
-                            Download
+                            Access/Download
                         </v-btn>
                         <powButton v-else :btn="true" :resource="useResource.metadata"/>
                         <v-btn v-if="!datasetBeingEdited" small depressed text class="px-0" color="label_colour"

--- a/frontend/src/components/pages/resource.vue
+++ b/frontend/src/components/pages/resource.vue
@@ -97,7 +97,7 @@
                 </v-btn>
 
                 <v-btn v-if="!editing && !loadPOW" small depressed text color="primary" :href="resource.url">
-                    <v-icon>mdi-download</v-icon>&nbsp;{{$tc('Download')}}
+                    <v-icon>mdi-open-in-new</v-icon>&nbsp;{{$tc('Access/Download')}}
                 </v-btn>
 
                 <v-btn v-if="!editing && showEdit" small depressed text color="primary" :to="{ name: 'resource_create', params: { datasetId: dataset.name }}">
@@ -260,6 +260,7 @@ export default {
     },
 
     computed: {
+
         loadPOW: function() {
             return (this.resource.bcdc_type=="geographic" && ("object_name" in this.resource) && this.resource.name.toLowerCase().indexOf("custom download") !== -1);
         },

--- a/frontend/src/components/pages/resource.vue
+++ b/frontend/src/components/pages/resource.vue
@@ -76,7 +76,7 @@
                     </v-dialog>
                 </v-btn>
 
-                <powButton :resource="resource" v-if="!editing && resource && loadPOW" btn/>
+                <powButton :resource="resource" v-if="!editing && resource && loadPOW" btn icon/>
 
                 <v-btn v-if="!!preview.hasSchema && !editing" :disabled="previewLoading" depressed small text color="primary" @click.stop="schemaDialog = true">
                     <v-icon v-if="!previewLoading">mdi-code-braces</v-icon>

--- a/frontend/src/components/pow/powButton.vue
+++ b/frontend/src/components/pow/powButton.vue
@@ -3,11 +3,18 @@
         <template v-slot:activator="{ on }">
             <v-btn v-if="btn" small depressed text color="primary" v-on="on">
                 <!-- @click="startOrder()" -->
-                <!-- <v-icon>mdi-folder-information-outline</v-icon>&nbsp; -->{{$tc('Access/Download')}}
+                <!-- <v-icon>mdi-folder-information-outline</v-icon>&nbsp; -->
+
+                <v-icon v-if="icon">mdi-open-in-new</v-icon>
+
+                {{$tc('Access/Download')}}
             </v-btn>
             <v-list-item v-else text block color="label_colour" v-on="on">
+
+                <v-icon v-if="icon">mdi-open-in-new</v-icon>
+
                 <!-- @click="startOrder()" -->
-                Access/Download
+                {{$tc('Access/Download')}}
             </v-list-item>
         </template>
         <!-- change to vue component and move methods to here -->
@@ -30,7 +37,8 @@ const powServ = new PowApi();
 export default {
     props: {
         resource: Object,
-        btn: Boolean
+        btn: Boolean,
+        icon: Boolean
     },
     data() {
         return {

--- a/frontend/src/components/pow/powButton.vue
+++ b/frontend/src/components/pow/powButton.vue
@@ -3,11 +3,11 @@
         <template v-slot:activator="{ on }">
             <v-btn v-if="btn" small depressed text color="primary" v-on="on">
                 <!-- @click="startOrder()" -->
-                <!-- <v-icon>mdi-folder-information-outline</v-icon>&nbsp; -->{{$tc('Request Access')}}
+                <!-- <v-icon>mdi-folder-information-outline</v-icon>&nbsp; -->{{$tc('Access/Download')}}
             </v-btn>
             <v-list-item v-else text block color="label_colour" v-on="on">
                 <!-- @click="startOrder()" -->
-                Request Access
+                Access/Download
             </v-list-item>
         </template>
         <!-- change to vue component and move methods to here -->

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -283,6 +283,7 @@ export default {
         "Edit Resource": "Edit Resource",
         "Delete Resource": "Delete Resource",
         "Request Access": "Request Access",
+        "Access/Download": "Access/Download",
         "Viewing Resource": "Viewing Resource",
         "Scroll to Top": "Scroll to Top",
         "Permalink URL Copied to Clipboard": "Permalink URL Copied to Clipboard",

--- a/frontend/src/i18n/fr.js
+++ b/frontend/src/i18n/fr.js
@@ -283,6 +283,7 @@ export default {
         "Edit Resource": "Modifier la Ressource",
         "Delete Resource": "Supprimer la ressource",
         "Request Access": "Demande d'accès",
+        "Access/Download": "Accéder/Télécharger",
         "Viewing Resource": "Affichage de la ressource",
         "Scroll to Top": "Faire défiler vers le haut",
         "Permalink URL Copied to Clipboard": "URL du lien permanent copiée dans le presse-papiers",


### PR DESCRIPTION
For bcgov#364, changed the wording for the "Download" and "Request Access" buttons to use the verbiage "Access/Download" universally. This button uses the "open in new" icon which conforms with precedent set by classic catalogue.

![image](https://user-images.githubusercontent.com/5297264/131733265-7ad3d638-9412-4d90-b1d2-8ca804720859.png)
