### PR TITLE
Fix logout behaviour

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -44,13 +44,16 @@ router.use('/callback', passport.authenticate('oidc'), function(req, res, next){
 
 router.use('/logout', function(req, res, next){
     req.session.destroy();
+
     var redirectTo = config.get('frontend') + req.query.r;
     redirectTo += redirectTo.indexOf("?") >= 0 ? "&" : "?";
     redirectTo += "loggedOut=true";
 
-    if (config.has('oidc.logout')){
-        redirectTo = encodeURIComponent(redirectTo);
-        redirectTo = config.get('oidc.logout') + "?redirect_uri=" + redirectTo
+    if (config.has('oidc.logout')) {
+        let oidcLogoutURL = new URL(config.get("oidc.logout"));
+        oidcLogoutURL.searchParams.set("client_id", config.get("oidc.clientID"));
+        oidcLogoutURL.searchParams.set("redirect_uri", redirectTo);
+        redirectTo = oidcLogoutURL.toString();
     }
 
     req.logout();


### PR DESCRIPTION
Users do not currently have to enter credentials when they click log in immediately after logging out. This remedies that, per bcgov#542.