### PR TITLE
Added Documentation to the hamburger menu

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -160,26 +160,14 @@ export default {
         stayLoggedIn: false,
         findText: this.$store.state.search.searchText ? this.$store.state.search.searchText : "",
         menuSecondary: [
-            // {
-            //     "title": "What is DataBC?",
-            //     "href": "http://www2.gov.bc.ca/gov/content/governments/about-the-bc-government/databc"
-            // },
-            // {
-            //     "title": "Dataset Usage",
-            //     "link": "/usage"
-            // },
             {
                 "title": "Geographic Services",
                 "href": "https://www2.gov.bc.ca/gov/content/data/geographic-data-services"
             },
-            // {
-            //     "title": "Blog",
-            //     "href": "https://engage.gov.bc.ca/data/"
-            // },
-            // {
-            //     "title": "Developers",
-            //     "href": "https://www.bcdevexchange.org/"
-            // },
+            {
+                "title": "Documentation",
+                "href": "https://www2.gov.bc.ca/gov/content?id=42230A1DCE4B442A8D72B7B11A53DA5F"
+            },
             {
                 "title": "About",
                 "link": "/about",

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -10,6 +10,7 @@ export default {
         "SearchDatasets": "Search Data Catalogue",
         "What is DataBC?": "What is DataBC?",
         "Geographic Services": "Geographic Services",
+        "Documentation": "Documentation",
         "Blog": "Blog",
         "Developers": "Developers",
         "Contact": "Contact",

--- a/frontend/src/i18n/fr.js
+++ b/frontend/src/i18n/fr.js
@@ -10,6 +10,7 @@ export default {
         "SearchDatasets": "Recherche dans le Catalogue de Données",
         "What is DataBC?": "Qu'est-ce que DataBC?",
         "Geographic Services": "Services géographiques",
+        "Documentation": "Documentation",
         "Blog": "Blog",
         "Developers": "Développeurs",
         "Contact": "Contact",


### PR DESCRIPTION
Added a link to the hamburger menu per bcgov#535. Also removed some commented out menu links; will rely on git commit history to restore them if ever needed. French translation for documentation is documentation according to Google translate.