### PR TITLE
Added custom UI for delete modal

### DIFF
--- a/frontend/src/components/DeleteButton.vue
+++ b/frontend/src/components/DeleteButton.vue
@@ -1,0 +1,72 @@
+<template>
+  <v-dialog v-model="showDialog" content-class="deletion-confirmation-dialog">
+    <template v-slot:activator="{ on }">
+      <v-btn text small depressed :class="buttonClass" color="error_text" v-on="on">
+        <v-icon>mdi-trash-can-outline</v-icon><span v-html="fullButtonText"></span>
+      </v-btn>
+    </template>
+    <v-card>
+        <v-card-title>{{$tc("Please Confirm Action")}}</v-card-title>
+
+        <v-card-text>
+          {{$tc(confirmationMessage)}}
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer></v-spacer> <v-btn @click="cancel" color="secondary">{{$tc("Cancel")}}</v-btn> <v-btn @click="confirm" color="primary">{{$tc("Okay")}}</v-btn>
+        </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+
+  export default {
+    data: () => ({
+      showDialog: false
+    }),
+
+    props: {
+
+      confirmationMessage: {
+        type: String,
+        default: "Are you sure?"
+      },
+
+      buttonText: {
+        type: String,
+        default: ""
+      },
+
+      buttonClass: {
+        type: String,
+        default: ""
+      }
+    },
+
+    computed: {
+      fullButtonText() {
+        return this.buttonText ? '&nbsp;' + this.$tc(this.buttonText) : '';
+      }
+    },
+
+    methods: {
+      cancel() {
+        this.$emit("cancel");
+        this.showDialog = false;
+      },
+
+      confirm() {
+        this.$emit("delete");
+        this.showDialog = false;
+      }
+    }
+  };
+
+</script>
+
+<style scoped>
+  >>> .deletion-confirmation-dialog {
+    max-width: 430px;
+  }
+</style>

--- a/frontend/src/components/DeleteButton.vue
+++ b/frontend/src/components/DeleteButton.vue
@@ -13,7 +13,7 @@
         </v-card-text>
 
         <v-card-actions>
-          <v-spacer></v-spacer> <v-btn @click="cancel" color="secondary">{{$tc("Cancel")}}</v-btn> <v-btn @click="confirm" color="primary">{{$tc("Okay")}}</v-btn>
+          <v-spacer></v-spacer> <v-btn @click="cancel" color="secondary">{{$tc("Cancel")}}</v-btn> <v-btn @click="confirm" color="primary">{{$tc("Confirm")}}</v-btn>
         </v-card-actions>
     </v-card>
   </v-dialog>

--- a/frontend/src/components/dataset/ResourceCard.vue
+++ b/frontend/src/components/dataset/ResourceCard.vue
@@ -41,6 +41,7 @@
                         </v-btn>
                         <DeleteButton
                                 v-if="canDelete"
+                                buttonClass="px-0 mx-0"
                                 confirmationMessage="Are you sure you want to delete this resource?"
                                 @delete="deleteResource">
                         </DeleteButton>

--- a/frontend/src/components/dataset/ResourceCard.vue
+++ b/frontend/src/components/dataset/ResourceCard.vue
@@ -39,9 +39,11 @@
                             :to="{ name: 'resource_view', query: { editing: true }, params: { datasetId: dataset.name, resourceId: resource.id }}">
                             <v-icon>mdi-pencil</v-icon>
                         </v-btn>
-                        <v-btn v-if="canDelete" @click="deleteResource" small depressed text class="px-0 mx-0" color="error_text" >
-                            <v-icon>mdi-trash-can-outline</v-icon>
-                        </v-btn>
+                        <DeleteButton
+                                v-if="canDelete"
+                                confirmationMessage="Are you sure you want to delete this resource?"
+                                @delete="deleteResource">
+                        </DeleteButton>
                     </span>
                 </v-col>
 
@@ -52,8 +54,9 @@
 
 <script>
 import { mapState } from 'vuex';
-import powButton from "../pow/powButton"
-import { CkanApi } from '../../services/ckanApi'
+import powButton from "../pow/powButton";
+import DeleteButton from '../DeleteButton';
+import { CkanApi } from '../../services/ckanApi';
 const ckanServ = new CkanApi()
 
 export default {
@@ -65,19 +68,18 @@ export default {
         canDelete: {
             type: Boolean,
             default: false,
-        },
+        }
     },
 
     components: {
-        powButton: powButton
+        powButton: powButton,
+        DeleteButton
     },
     methods: {
         deleteResource: function(){
-            if (confirm("Are you sure you want to delete this resource?")) {
-                ckanServ.deleteResource(this.resource.id).then( () => {
-                    location.reload();
-                });
-            }
+            ckanServ.deleteResource(this.resource.id).then( () => {
+                location.reload();
+            });
         }
     },
     computed: {

--- a/frontend/src/components/pages/dataset_view.vue
+++ b/frontend/src/components/pages/dataset_view.vue
@@ -133,9 +133,12 @@
                     {{$tc('Add Resource')}}
                 </v-btn>
 
-                <v-btn text small depressed v-if="!createMode && showEdit && isAdmin" color="error_text" @click="deleteDataset">
-                    <v-icon>mdi-trash-can-outline</v-icon>&nbsp;{{$tc("Delete Dataset")}}
-                </v-btn>
+                <DeleteButton
+                    v-if="!createMode && showEdit && isAdmin"
+                    buttonText="Delete Dataset"
+                    confirmationMessage="Are you sure you want to delete this record and all its resources?"
+                    @delete="deleteDataset">
+                </DeleteButton>
 
                 <v-btn v-if="editing" depressed @click="cancel">{{$tc('Cancel')}}</v-btn>
 
@@ -219,12 +222,14 @@ import {CkanApi} from '../../services/ckanApi';
 const ckanServ = new CkanApi();
 
 import DynamicForm from '../form/DynamicForm';
+import DeleteButton from '../DeleteButton';
 
 export default {
     components: {
         DynamicForm: DynamicForm,
         ResourceList: ResourceList,
         ValidationObserver: ValidationObserver,
+        DeleteButton
     },
     data() {
         let schemaName = 'bcdc_dataset';
@@ -507,28 +512,25 @@ export default {
             this.showFormSuccess = false;
         },
         async deleteDataset(){
-            if (confirm("Are you sure you want to delete this record and all its resources?")) {
+            const response = await ckanServ.deleteDataset(this.datasetId);
 
-                const response = await ckanServ.deleteDataset(this.datasetId);
+            this.formSuccess = "";
+            this.formError = "";
 
-                this.formSuccess = "";
-                this.formError = "";
-
-                if (response.success && response.success === true && (!response.error || response.error === false)){
-                    this.formSuccess = "Successfully deleted";
-                    this.showFormSuccess = true;
-                    this.showFormError = false;
-                    return;
-                } else if (response.error){
-                    this.formError = response.error;
-                    this.showFormSuccess = false;
-                    this.showFormError = true;
-                    return;
-                }
-                this.formError = "Unknown error deleting dataset";
+            if (response.success && response.success === true && (!response.error || response.error === false)){
+                this.formSuccess = "Successfully deleted";
+                this.showFormSuccess = true;
+                this.showFormError = false;
+                return;
+            } else if (response.error){
+                this.formError = response.error;
                 this.showFormSuccess = false;
                 this.showFormError = true;
+                return;
             }
+            this.formError = "Unknown error deleting dataset";
+            this.showFormSuccess = false;
+            this.showFormError = true;
         },
         cancel(){
             if (this.createMode){

--- a/frontend/src/components/pages/resource.vue
+++ b/frontend/src/components/pages/resource.vue
@@ -108,9 +108,12 @@
                     <v-icon>mdi-pencil-outline</v-icon>&nbsp;{{$tc("Edit Resource")}}
                 </v-btn>
                 
-                <v-btn v-if="!editing && canDeleteResources" small depressed text color="error_text" @click="deleteResource">
-                    <v-icon>mdi-trash-can-outline</v-icon>&nbsp;{{$tc("Delete Resource")}}
-                </v-btn>
+                <DeleteButton
+                        v-if="!editing && canDeleteResources"
+                        buttonText="Delete Resource"
+                        confirmationMessage="Are you sure you want to delete this resource?"
+                        @delete="deleteResource">
+                </DeleteButton>
                 
                 <v-btn v-if="editing" depressed @click="cancel">Cancel</v-btn>
                 <v-btn v-if="editing" depressed color="primary" type="submit" @click="submit()">Save</v-btn>
@@ -200,6 +203,7 @@ import DynamicForm from '../form/DynamicForm';
 import Preview from "../resources/preview";
 import JsonTable from "../resources/jsontable";
 import powButton from "../pow/powButton";
+import DeleteButton from '../DeleteButton';
 
 export default {
     components: {
@@ -208,7 +212,8 @@ export default {
         ValidationObserver: ValidationObserver,
         Preview: Preview,
         JsonTable: JsonTable,
-        powButton: powButton
+        powButton: powButton,
+        DeleteButton
     },
     data() {
         let schemaName = 'bcdc_dataset';
@@ -427,27 +432,25 @@ export default {
             }
         },
         async deleteResource() {
-            if (confirm("Are you sure you want to delete this resource?")) {
-                const response = await ckanServ.deleteResource(this.resourceId);
+            const response = await ckanServ.deleteResource(this.resourceId);
 
-                this.formSuccess = "";
-                this.formError = "";
+            this.formSuccess = "";
+            this.formError = "";
 
-                if (response.success && response.success === true && (!response.error || response.error === false)){
-                    this.formSuccess = "Successfully deleted";
-                    this.showFormSuccess = true;
-                    this.showFormError = false;
-                    return;
-                } else if (response.error){
-                    this.formError = response.error;
-                    this.showFormSuccess = false;
-                    this.showFormError = true;
-                    return;
-                }
-                this.formError = "Unknown error deleting resource";
+            if (response.success && response.success === true && (!response.error || response.error === false)){
+                this.formSuccess = "Successfully deleted";
+                this.showFormSuccess = true;
+                this.showFormError = false;
+                return;
+            } else if (response.error){
+                this.formError = response.error;
                 this.showFormSuccess = false;
                 this.showFormError = true;
+                return;
             }
+            this.formError = "Unknown error deleting resource";
+            this.showFormSuccess = false;
+            this.showFormError = true;
         },
         cancel(){
             if (this.createMode){


### PR DESCRIPTION
Per bcgov#518, replaced the browser-native confirmation dialog for deletions with a custom one built on Vuetify.

 - Baked this into a new component, `<DeleteButton>`, which allows delete handlers to be attached and messaging to be modified through properties
 -  Did not change any of the logic for where and how this delete button is actually shown

The new dialog should look like this:

![image](https://user-images.githubusercontent.com/5297264/132927320-8eb52d25-e530-46c4-96b9-bd7c622e35b2.png)

The button look and feel should remain the same.
