### PR TITLE
Added apibridge/* route for API bridge traffic

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,14 +1,13 @@
 *:8080 {
     root /app
     errors visible
-    #rewrite not /api/.* {path} /
-
+    
     rewrite {
-        if {path} not_match ^\/(api\/.*|resourceCreate|resourceUpdate|sitemap.xml|sitemap.html|robots.txt)
+        if {path} not_match ^\/(apibridge\/.*|resourceCreate|resourceUpdate|sitemap.xml|sitemap.html|robots.txt)
         to {path} /
     }
 
-    proxy /api/ http://{$HOSTNAME}:3000/
+    proxy /apibridge/ http://{$HOSTNAME}:3000/
     proxy /resourceCreate {$CKAN_URL}/api/3/action/resource_create {
         without /resourceCreate
     }

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -23,11 +23,11 @@ module.exports = {
                 }
             },
 
-            '/api': {
+            '/apibridge': {
                 target: 'http://localhost:3000/',
                 changeOrigin: true,
                 pathRewrite: {
-                    '^/api': "/api"
+                    '^/apibridge': "/apibridge"
                 }
             }
         }


### PR DESCRIPTION
To keep classic CKAN API and the API bridge cleanly separated, sending all bridge API requests to a newly created apibridge/* route.