### PR TITLE
Updated client API to be accessible at different routes

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,11 +4,11 @@
     #rewrite not /api/.* {path} /
 
     rewrite {
-        if {path} not_match ^\/(api\/.*|resourceCreate|resourceUpdate|sitemap.xml|sitemap.html|robots.txt)
+        if {path} not_match ^\/((?:client-)?api\/.*|resourceCreate|resourceUpdate|sitemap.xml|sitemap.html|robots.txt)
         to {path} /
     }
 
-    proxy /api/ http://{$HOSTNAME}:3000/
+    proxy /client-api/ http://{$HOSTNAME}:3000/
     proxy /resourceCreate {$CKAN_URL}/api/3/action/resource_create {
         without /resourceCreate
     }

--- a/backend/app.js
+++ b/backend/app.js
@@ -97,7 +97,7 @@ var strategy = new OidcStrategy(config.get('oidc'), function(issuer, sub, profil
 // set up passport
 passport.use('oidc', strategy);
 
-app.use('/api/version', function(req, res){
+app.use('/client-api/version', function(req, res){
   var hash = (process.env.GITHASH) ? process.env.GITHASH : "";
   var pjson = require('./package.json');
   var v = pjson.version;
@@ -157,12 +157,12 @@ app.use('/api/version', function(req, res){
   });
 })
 
-app.use('/api/solr', solrRouter);
-app.use('/api/resource', resourceRouter);
-app.use('/api/ckan', ckanRouter);
-app.use('/api/pow', powRouter);
-app.use('/api/an', analyticsRouter);
-app.use('/api', authRouter);
+app.use('/client-api/solr', solrRouter);
+app.use('/client-api/resource', resourceRouter);
+app.use('/client-api/ckan', ckanRouter);
+app.use('/client-api/pow', powRouter);
+app.use('/client-api/an', analyticsRouter);
+app.use('/client-api', authRouter);
 app.use('/status', function(req, res){
   res.json({"status": "OK"}).status(200);
 });

--- a/backend/config/default.json
+++ b/backend/config/default.json
@@ -13,7 +13,7 @@
     "userInfoURL": "https://{yourdomain}/oauth2/default/v1/userinfo",
     "clientID": "{ClientID}",
     "clientSecret": "{ClientSecret}",
-    "callbackURL": "http://localhost:3000/api/callback",
+    "callbackURL": "http://localhost:3000/client-api/callback",
     "scope": "openid profile offline_access"
   },
 

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -7,7 +7,7 @@ let config = require('config');
 
 router.use('/login', function(req, res, next){
     req.session.r = req.query.r;
-    return res.redirect('/api/log');
+    return res.redirect('/client-api/log');
 });
 
 router.use("/groupSeperator", function(req,res,next){

--- a/backend/routes/ckan/misc.js
+++ b/backend/routes/ckan/misc.js
@@ -25,7 +25,7 @@ var addRoutes = function(router){
             let newUrl = config.get('frontend');
             if (body){
                 let b = body.replace(oldUrl, newUrl);
-                b = b.replace("/feeds/recent.rss", "/api/ckan/rss");
+                b = b.replace("/feeds/recent.rss", "/client-api/ckan/rss");
                 return res.end(b);
             }return res.end('Sorry there was an error getting the rss feed: ', err)
         });

--- a/backend/routes/seo.js
+++ b/backend/routes/seo.js
@@ -47,6 +47,7 @@ router.get('/robots.txt', auth.removeExpired, function(req, res, next) {
     }
 
     r += "Disallow: /api/\n";
+    r += "Disallow: /client-api/\n";
     r += "Disallow: /dataset/activity\n";
     r += "Disallow: /dataset/*/history\n";
     r += "Disallow: /dataset/rate/\n";

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -150,8 +150,8 @@ export default {
     let locale = (window.navigator.userLanguage || window.navigator.language).substring(0,2);
     return {
         aboutDialog: false,
-        logInUrl: "/api/login?r="+this.$router.history.current.fullPath,
-        logoutUrl: "/api/logout?r="+window.location.pathname,
+        logInUrl: "/client-api/login?r="+this.$router.history.current.fullPath,
+        logoutUrl: "/client-api/logout?r="+window.location.pathname,
         showLoggedOut: false,
         loadedLanguages: locale === "fr" ? ['fr', 'en'] : ['en'],
         classicUrl: '',
@@ -185,7 +185,7 @@ export default {
   },
   watch: {
     $route(to){
-      this.logInUrl = "/api/login?r="+to.fullPath;
+      this.logInUrl = "/client-api/login?r="+to.fullPath;
       this.$store.dispatch('user/getCurrentUser')
       if (this.$route.query.loggedOut === "true"){
         this.showLoggedOut = true;
@@ -247,7 +247,7 @@ export default {
                 "icon": "mdi-rss-box",
                 "iconColour": "orange",
                 "title": "Subscribe to New Data",
-                "href": '/api/ckan/rss'
+                "href": '/client-api/ckan/rss'
             },
             {
                 "title": "Classic Catalogue",

--- a/frontend/src/components/pages/home.vue
+++ b/frontend/src/components/pages/home.vue
@@ -137,7 +137,7 @@
   export default{
       data () {
         return {
-          logInUrl: "/api/login?r=/",
+          logInUrl: "/client-api/login?r=/",
           cardDialog: false,
           searchText: "",
           redrawIndex: 0,

--- a/frontend/src/components/user/user.vue
+++ b/frontend/src/components/user/user.vue
@@ -22,7 +22,7 @@ export default{
     },
     data() {
         return {
-            logoutUrl: "/api/logout?r="+window.location.pathname,
+            logoutUrl: "/client-api/logout?r="+window.location.pathname,
         }
     },
     methods: {

--- a/frontend/src/services/analytics.js
+++ b/frontend/src/services/analytics.js
@@ -4,7 +4,7 @@ export class Analytics {
     constructor(){}
 
     ga(){
-        const url = '/api/an/ga'
+        const url = '/client-api/an/ga'
         try{
             return axios.get(url, {withCredentials: true}).then(response => response.data)
         }catch(ex){
@@ -13,7 +13,7 @@ export class Analytics {
     }
 
     get(pageUrl, pageTitle, referrer){
-        const url = '/api/an?pageUrl='+pageUrl+"&pageTitle="+pageTitle+"&referrer="+referrer
+        const url = '/client-api/an?pageUrl='+pageUrl+"&pageTitle="+pageTitle+"&referrer="+referrer
         try{
             return axios.get(url, {withCredentials: true}).then(response => response.data)
         }catch(ex){
@@ -22,7 +22,7 @@ export class Analytics {
     }
 
     post(pageUrl, pageTitle, referrer){
-        const url = '/api/an?pageUrl='+encodeURI(pageUrl)+"&pageTitle="+encodeURI(pageTitle)+"&referrer="+encodeURI(referrer)
+        const url = '/client-api/an?pageUrl='+encodeURI(pageUrl)+"&pageTitle="+encodeURI(pageTitle)+"&referrer="+encodeURI(referrer)
         try{
             return axios.post(url, {}, {withCredentials: true}).then(response => response.data)
         }catch(ex){

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -4,17 +4,17 @@ export class Auth {
     constructor(){}
 
     getToken(){
-        const url = '/api/token'
+        const url = '/client-api/token'
         return axios.get(url, {withCredentials: true}).then(response => response.data)
     }
 
     groupSeperator(){
-        const url = '/api/groupSeperator';
+        const url = '/client-api/groupSeperator';
         return axios.get(url).then(response => response.data);
     }
 
     sysAdminGroup(){
-        const url = '/api/sysAdminGroup';
+        const url = '/client-api/sysAdminGroup';
         return axios.get(url).then(response => response.data);
     }
 

--- a/frontend/src/services/ckanApi.js
+++ b/frontend/src/services/ckanApi.js
@@ -5,67 +5,67 @@ export class CkanApi {
     constructor(){}
 
     getClassic() {
-        const url = '/api/ckan/classic';
+        const url = '/client-api/ckan/classic';
         return axios.get(url).then(response => response.data);
     }
 
     getLandingTerms() {
-        const url = '/api/ckan/landingTerms';
+        const url = '/client-api/ckan/landingTerms';
         return axios.get(url).then(response => response.data);
     }
 
     getDatasets(queryString) {
-        const url = '/api/ckan/search'+queryString;
+        const url = '/client-api/ckan/search'+queryString;
         return axios.get(url, {withCredentials: true, timeout: apiConfig.timeout}).then(response => response.data);
     }
 
     getDataset(id) {
-        const url = '/api/ckan/dataset?id='+id;
+        const url = '/client-api/ckan/dataset?id='+id;
         return axios.get(url, {withCredentials: true}).then(response => response.data);
     }
 
     putDataset(dataset) {
-        const url = '/api/ckan/dataset';
+        const url = '/client-api/ckan/dataset';
         return axios.put(url, dataset, {withCredentials: true}).then(response => response.data);
     }
 
     postDataset(dataset) {
-        const url = '/api/ckan/dataset';
+        const url = '/client-api/ckan/dataset';
         return axios.post(url, dataset, {withCredentials: true}).then(response => response.data);
     }
 
     deleteDataset(id) {
-        const url = '/api/ckan/dataset/'+id;
+        const url = '/client-api/ckan/dataset/'+id;
         return axios.delete(url, { withCredentials: true }).then(response => response.data);
     }
 
     getFacets(){
-        const url = '/api/ckan/facets';
+        const url = '/client-api/ckan/facets';
         return axios.get(url, {withCredentials: true}).then(response => response.data);
     }
 
     getOrganization(id){
-        const url = '/api/ckan/organization?id='+id;
+        const url = '/client-api/ckan/organization?id='+id;
         return axios.get(url, {withCredentials: true, timeout: apiConfig.timeout}).then(response => response.data);
     }
 
     getOrgList() {
-        const url = '/api/ckan/organizations';
+        const url = '/client-api/ckan/organizations';
         return axios.get(url, {withCredentials: true}).then(response => response.data);
     }
 
     getOrgListNoCache() {
-        const url = '/api/ckan/organizations?nocache=true';
+        const url = '/client-api/ckan/organizations?nocache=true';
         return axios.get(url, {withCredentials: true}).then(response => response.data);
     }
 
     getUserOrgList() {
-        const url = '/api/ckan/userOrganizations';
+        const url = '/client-api/ckan/userOrganizations';
         return axios.get(url, {withCredentials: true, timeout: apiConfig.timeout}).then(response => response.data);
     }
 
     getActivity(user_id) {
-        let url = '/api/ckan/activity';
+        let url = '/client-api/ckan/activity';
         if ( (typeof(user_id) !== "undefined") && (user_id != "") ){
             url += '/' + user_id;
         }
@@ -73,52 +73,52 @@ export class CkanApi {
     }
 
     getUser(user_id) {
-        const url = '/api/ckan/user/'+user_id;
+        const url = '/client-api/ckan/user/'+user_id;
         return axios.get(url, {withCredentials: true}).then(response => response.data);
     }
 
     getTags() {
-        const url = '/api/ckan/tagList';
+        const url = '/client-api/ckan/tagList';
         return axios.get(url, {withCredentials: true}).then(response => response.data)
     }
 
     getVocabs() {
-        const url = '/api/ckan/vocabList';
+        const url = '/client-api/ckan/vocabList';
         return axios.get(url, {withCredentials: true}).then(response => response.data)
     }
 
     getLicenses() {
-        const url = '/api/ckan/licenseList';
+        const url = '/client-api/ckan/licenseList';
         return axios.get(url, {withCredentials: true}).then(response => response.data)
     }
 
     getGroupList() {
-        const url = '/api/ckan/groups';
+        const url = '/client-api/ckan/groups';
         return axios.get(url, {withCredentials: true, timeout: apiConfig.timeout}).then(response => response.data);
     }
 
     getUserGroupList() {
-        const url = '/api/ckan/userGroups';
+        const url = '/client-api/ckan/userGroups';
         return axios.get(url, {withCredentials: true, timeout: apiConfig.timeout}).then(response => response.data);
     }
 
     getGroup(id) {
-        const url = '/api/ckan/group/'+id;
+        const url = '/client-api/ckan/group/'+id;
         return axios.get(url, {withCredentials: true, timeout: apiConfig.timeout}).then(response => response.data);
     }
 
     getAbout() {
-        const url = '/api/ckan/about';
+        const url = '/client-api/ckan/about';
         return axios.get(url, {withCredentials: true}).then(response => response.data);
     }
 
     putAbout(about) {
-        const url = '/api/ckan/about';
+        const url = '/client-api/ckan/about';
         return axios.put(url, {about: about}, {withCredentials: true}).then(response => response.data);
     }
 
     getDatasetSchema(type) {
-        let url = '/api/ckan/datasetSchema';
+        let url = '/client-api/ckan/datasetSchema';
         if (typeof(type) !== "undefined"){
            url += "?type=" +type;
         }
@@ -126,7 +126,7 @@ export class CkanApi {
     }
 
     getGroupSchema(/*type*/) {
-        let url = '/api/ckan/groupSchema';
+        let url = '/client-api/ckan/groupSchema';
         // if (typeof(type) !== "undefined"){
         //    url += "?type=" +type;
         // }
@@ -134,7 +134,7 @@ export class CkanApi {
     }
 
     getGeneric(ckanUrl) {
-        let url = '/api/ckan/?url='+encodeURIComponent(ckanUrl);
+        let url = '/client-api/ckan/?url='+encodeURIComponent(ckanUrl);
         return axios.get(url, {withCredentials: true}).then(response => response.data);
     }
 
@@ -172,47 +172,47 @@ export class CkanApi {
     }
 
     deleteResource(id) {
-        const url = '/api/ckan/resource/'+id;
+        const url = '/client-api/ckan/resource/'+id;
         return axios.delete(url, { withCredentials: true }).then(response => response.data);
     }
 
     deleteGroup(id){
-        const url = '/api/ckan/group/'+id;
+        const url = '/client-api/ckan/group/'+id;
         return axios.delete(url, { withCredentials: true }).then(response => response.data);
     }
 
     postGroup(group) {
-        const url = '/api/ckan/group';
+        const url = '/client-api/ckan/group';
         return axios.post(url, group, {withCredentials: true}).then(response => response.data);
     }
 
     putGroup(group) {
-        const url = '/api/ckan/group/'+group.id;
+        const url = '/client-api/ckan/group/'+group.id;
         return axios.put(url, group, {withCredentials: true}).then(response => response.data);
     }
 
     getGroupActivity(group) {
-        const url = '/api/ckan/group_activity/'+group;
+        const url = '/client-api/ckan/group_activity/'+group;
         return axios.get(url, group, {withCredentials: true}).then(response => response.data);
     }
 
     getGroupMembers(group) {
-        const url = '/api/ckan/members/'+group;
+        const url = '/client-api/ckan/members/'+group;
         return axios.get(url, {withCredentials: true}).then(response => response.data);
     }
 
     deleteGroupMember(groupId,  member){
-        const url = '/api/ckan/members/'+groupId;
+        const url = '/client-api/ckan/members/'+groupId;
         return axios.delete(url, { data: {object_type: 'user', object: member} }, {withCredentials: true}).then(response => response.data);
     }
 
     getGroupFollowing(groupId){
-        const url = '/api/ckan/group/'+groupId+'/following';
+        const url = '/client-api/ckan/group/'+groupId+'/following';
         return axios.get(url, {withCredentials: true}).then(response => response.data);
     }
 
     followGroup(groupId, apiKey){
-        const url = '/api/ckan/group/'+groupId+'/follow';
+        const url = '/client-api/ckan/group/'+groupId+'/follow';
         let body = {
             api_key: apiKey
         };
@@ -220,32 +220,32 @@ export class CkanApi {
     }
 
     unfollowGroup(groupId, apiKey){
-        const url = '/api/ckan/group/'+groupId+'/unfollow';
+        const url = '/client-api/ckan/group/'+groupId+'/unfollow';
         return axios.delete(url, { data: {api_key: apiKey} }, {withCredentials: true}).then(response => response.data);
     }
 
     getOrgSchema(){
-        let url = '/api/ckan/orgSchema';
+        let url = '/client-api/ckan/orgSchema';
         return axios.get(url, {withCredentials: true}).then(response => response.data);
     }
 
     postOrg(group) {
-        const url = '/api/ckan/organization';
+        const url = '/client-api/ckan/organization';
         return axios.post(url, group, {withCredentials: true}).then(response => response.data);
     }
 
     putOrg(group) {
-        const url = '/api/ckan/organization/'+group.id;
+        const url = '/client-api/ckan/organization/'+group.id;
         return axios.put(url, group, {withCredentials: true}).then(response => response.data);
     }
 
     deleteOrg(id){
-        const url = '/api/ckan/organization/'+id;
+        const url = '/client-api/ckan/organization/'+id;
         return axios.delete(url, { withCredentials: true }).then(response => response.data);
     }
 
     getUsage(startY, startM, endY, endM, count, publisher){
-        let url = '/api/ckan/usage'
+        let url = '/client-api/ckan/usage'
         let addedToUrl = false;
         if (startY){
             addedToUrl = true;
@@ -285,7 +285,7 @@ export class CkanApi {
     }
 
     getPublishers(){
-        let url = '/api/ckan/publishers'
+        let url = '/client-api/ckan/publishers'
         return axios.get(url, { withCredentials: true }).then(response => response.data);
     }
 

--- a/frontend/src/services/powApi.js
+++ b/frontend/src/services/powApi.js
@@ -4,12 +4,12 @@ export class PowApi {
     constructor(){}
 
     getPowConfig(){
-        const url = '/api/pow/powConfig'
+        const url = '/client-api/pow/powConfig'
         return axios.get(url).then(response => response.data)
     }
 
     getOfiConfig(){
-        const url = '/api/pow/ofiConfig';
+        const url = '/client-api/pow/ofiConfig';
         return axios.get(url).then(response => response.data);
     }
 }

--- a/frontend/src/services/resourceApi.js
+++ b/frontend/src/services/resourceApi.js
@@ -4,13 +4,13 @@ export class ResourceApi {
     constructor(){}
 
     getResource(id){
-        const url = '/api/resource/'+id
+        const url = '/client-api/resource/'+id
         return axios.get(url, {withCredentials: true}).then(response => response.data)
     }
 
     getPreview(previewUrl, json){
 
-        let url = '/api/resource/preview/'+encodeURIComponent(previewUrl)
+        let url = '/client-api/resource/preview/'+encodeURIComponent(previewUrl)
         if (json){
             url += "?json_table_schema=" + JSON.stringify(json);
         }

--- a/frontend/src/services/solrApi.js
+++ b/frontend/src/services/solrApi.js
@@ -4,12 +4,12 @@ export class SolrApi {
     constructor(){}
 
     getDatasets(queryString) {
-        const url = '/api/solr/select'+queryString
+        const url = '/client-api/solr/select'+queryString
         return axios.get(url).then(response => response.data)
     }
 
     getSchema() {
-        const url = '/api/solr/schema'
+        const url = '/client-api/solr/schema'
         return axios.get(url).then(response => response.data)
     }
 

--- a/frontend/src/services/version.js
+++ b/frontend/src/services/version.js
@@ -4,7 +4,7 @@ export class Version {
     constructor(){}
 
     getVersion(){
-        const url = '/api/version'
+        const url = '/client-api/version'
         return axios.get(url, {withCredentials: true}).then(response => response.data)
     }
 

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -23,11 +23,11 @@ module.exports = {
                 }
             },
 
-            '/api': {
+            '/client-api': {
                 target: 'http://localhost:3000/',
                 changeOrigin: true,
                 pathRewrite: {
-                    '^/api': "/api"
+                    '^/client-api': "/client-api"
                 }
             }
         }


### PR DESCRIPTION
In order to distinguish between client API routes and CKAN API routes, and in order to allow both to coexist comfortably using a single host name, all client API endpoints were moved over to `/client-api/*`.