### PR TITLE
Update secureUrl GET parameter for POW

### DIFF
--- a/frontend/src/components/dataset/ResourceCard.vue
+++ b/frontend/src/components/dataset/ResourceCard.vue
@@ -27,7 +27,7 @@
                         <v-btn v-if="!loadPOW" class="px-0" small depressed text :href="useResource.metadata.url" color="label_colour">
                             {{$tc("Access/Download")}}&nbsp;
                         </v-btn>
-                        <powButton v-else :btn="true" :resource="useResource.metadata"/>
+                        <powButton v-else :btn="true" :dataset="dataset" :resource="useResource.metadata"/>
                         <v-btn v-if="!datasetBeingEdited" small depressed text class="px-0" color="label_colour"
                                 :to="{ name: 'resource_view', params: { datasetId: dataset.name, resourceId: resource.id}}">
                             {{$tc("View")}}

--- a/frontend/src/components/pages/resource.vue
+++ b/frontend/src/components/pages/resource.vue
@@ -76,7 +76,7 @@
                     </v-dialog>
                 </v-btn>
 
-                <powButton :resource="resource" v-if="!editing && resource && loadPOW" btn icon/>
+                <powButton :dataset="dataset" :resource="resource" v-if="!editing && resource && loadPOW" btn icon/>
 
                 <v-btn v-if="!!preview.hasSchema && !editing" :disabled="previewLoading" depressed small text color="primary" @click.stop="schemaDialog = true">
                     <v-icon v-if="!previewLoading">mdi-code-braces</v-icon>
@@ -359,7 +359,7 @@ export default {
             userOrgs: state => state.organization.userOrgs,
             datasetError: state => state.dataset.error,
             loggedIn: state => state.user.loggedIn,
-
+            organizations: state => state.organization.orgList,
             previewLoading: state => state.dataset.previewLoading,
             preview: state => state.dataset.preview,
             previewError: state => state.dataset.previewError,

--- a/frontend/src/components/pow/powButton.vue
+++ b/frontend/src/components/pow/powButton.vue
@@ -16,6 +16,7 @@ const powServ = new PowApi();
 
 export default {
     props: {
+        dataset: Object,
         resource: Object,
         btn: Boolean,
         icon: Boolean
@@ -53,6 +54,7 @@ export default {
             let public_url = this.get_ofi_url('/public/');
             let secure_url = this.get_ofi_url('/secure/');
 
+
             dwdspowapi.initialize(
                 public_url,
                 secure_url,
@@ -67,7 +69,9 @@ export default {
                         secureUrl: this.get_ofi_url('/secure/'),
                         customAoiUrl: this.custom_aoi_url,
                         pastOrdersNbr: this.past_orders_nbr,
-                        secureSite: false,
+                        secureSite: !!(this.dataset &&
+                                       this.dataset.download_audience &&
+                                       this.dataset.download_audience.toLowerCase() !== "public"),
                         orderSource: this.order_details.ordering_application
                     };
 


### PR DESCRIPTION
For bcgov#501, this sets the secureUrl parameter for the persistent order widget according to whether the dataset is downloadable by the public.

This solves a problem where secure custom downloads could not be initiated even if the requester has access privileges.

![image](https://user-images.githubusercontent.com/5297264/134282194-971a187c-45f9-4335-bf9a-3b507952f973.png)
