### PR TITLE
Change to how about page is loaded

### DIFF
--- a/backend/config/default.json
+++ b/backend/config/default.json
@@ -5,6 +5,7 @@
   "sessionSecret": "secret",
   "frontend": "http://localhost:8080",
   "classicUi": "http://127.0.0.1:5000",
+  "aboutPageUrl": "https://raw.githubusercontent.com/bcgov/ckan-ui/pages/pages/about.md",
 
   "oidc": {
     "issuer": "https://{yourdomain}/oauth2/default",
@@ -56,7 +57,6 @@
 
   "authGroupSeperator": "/",
   "sysAdminGroup": "admin",
-  "adminApiKey": "adminApiKeyHere",
 
   "landingTerms": ["Crown", "Waste", "Fire", "Lightning"]
 }

--- a/backend/routes/ckan/misc.js
+++ b/backend/routes/ckan/misc.js
@@ -394,85 +394,16 @@ var addRoutes = function(router){
     router.get('/about', auth.removeExpired, function(req, res, next) {
 
         let config = require('config');
-        let url = config.get('ckan');
 
-        let keys = Object.keys(req.query);
-        let reqUrl = url + "/api/3/action/config_option_show?key=ckan.site_about";
-
-        const options = {
-            url: reqUrl,
-            headers: {
-                'Authorization': config.get('adminApiKey')
-            }
-        };
-
-        request(options, function(err, apiRes, body){
-            if (err) {
-            console.log(err);
-            res.json({error: err});
-            return;
-            }
-            if (apiRes.statusCode !== 200){
-                console.log("Body Status? ", apiRes.statusCode);
-            }
-
-            if (apiRes.statusCode !== 200){
-                return res.json({
-                    "success": false,
-                    "result": 'Tx'
-                });
-            }
-
-            try {
-                let json = JSON.parse(body);
-                res.json(json);
-            }catch(ex){
-                console.error("Error reading json from ckan", ex);
-                res.json({error: ex});
-            }
-        });
-
-    });
-
-    /* UPDATE ckan about */
-    router.put('/about', auth.removeExpired, function(req, res, next) {
-        let config = require('config');
-        let url = config.get('ckan');
-    
-        const reqUrl = url + "/api/3/action/config_option_update";
-    
-        if (!req.user){
-            return res.json({error: "Not logged in"});
+        if (config.has("aboutPageUrl")) {
+            res.json({
+                "url": config.get("aboutPageUrl")
+            });
+        } else {
+            res.status(500)
+               .json({ "error": "aboutPageUrl must be provided in config" });
         }
-    
-        console.log("UPDATING ABOUT", req.body);
-
-        let body = {
-            'ckan.site_about': req.body.about
-        };
-    
-        request({ method: 'POST', uri: reqUrl, json: body, auth: { 'bearer': req.user.jwt } }, function(err, apiRes, body) {
-            if (err) {
-                console.log(err);
-                res.json({ error: err });
-                return;
-            }
-
-            if (apiRes.statusCode !== 200) {
-                console.log("Body Status? ", apiRes.statusCode);
-            }
-    
-            try {
-                let json = typeof(body) === 'string' ? JSON.parse(body) : body;
-                res.json(json);
-            } catch (ex) {
-                console.error("Error reading json from ckan", ex);
-                res.json({ error: ex, body: body });
-            }
-        });
-    
     });
-
 
 
 

--- a/frontend/src/components/pages/about.vue
+++ b/frontend/src/components/pages/about.vue
@@ -4,64 +4,35 @@
             <span>{{$tc('About')}}</span>
             <v-btn text small depressed class="noHover closeButton mr-7" @click="close"><v-icon color="text">mdi-close</v-icon></v-btn>
         </v-card-title>
-        <v-card-text :class="'px-0 content' + (editing ? ' editing' : '')">
-            <v-alert
-                :value="formSuccess"
-                class="fixed"
-                dismissible
-                type="success">
-                {{formMessage}}
-            </v-alert>
-            <v-alert
-                :value="formError"
-                class="fixed"
-                dismissible
-                type="error">
-                {{formMessage}}
-            </v-alert>
+        <v-card-text class="px-0 content">
             <div class="my-4 mr-3">
                 <v-progress-circular
-                    indeterminate
-                    color="light-blue"
-                    v-if="loading"
+                   indeterminate
+                   color="light-blue"
+                   v-if="loading"
                 ></v-progress-circular>
                 <Markdown
-                    v-else
-                    name="about"
-                    :value="about"
-                    label=""
-                    :editing="editing"
-                    :field="{}"
-                    scope="about"
-                    :disabled="disabled"
-                    @edited="(newValue) => { updateValues(newValue) }"
+                   v-else
+                   name="about"
+                   :value="about"
+                   label=""
+                   :field="{}"
+                   scope="about"
                 ></Markdown>
             </div>
         </v-card-text>
-        <v-card-actions>
-            <span v-if="showEdit" class="wide text-right align-right mr-3">
-                <v-spacer></v-spacer>
-                <v-btn @click="editing = true" depressed class="mr-3 control-button" color="primary">Edit</v-btn>
-            </span>
-            <span v-else-if="sysAdmin" class="wide text-right align-right mr-3">
-                <v-spacer></v-spacer>
-                <v-btn @click="save" depressed class="mr-3 control-button" color="primary">Save</v-btn>
-                <v-btn @click="cancel" depressed class="cancelButton mr-3">Cancel</v-btn>
-            </span>
-        </v-card-actions>
     </v-card>
 </template>
 
 <script>
+
+    import {CkanApi} from '../../services/ckanApi';
     import {Analytics} from '../../services/analytics';
-    const analyticsServ = new Analytics()
+    const analyticsServ = new Analytics;
+    const ckanServ = new CkanApi;
+
 
     import Markdown from '../form/components/Markdown';
-
-    import { CkanApi } from '../../services/ckanApi';
-    const ckanServ = new CkanApi();
-
-    import { mapState } from 'vuex';
 
     export default {
         components: {
@@ -70,66 +41,27 @@
 
         data() {
             return {
-                originalAbout: '',
                 about: '',
-                editing: false,
-                disabled: false,
-                loading: true,
-                formSuccess: false,
-                formError: false,
-                formMessage: "Succesfully udpated",
+                aboutUrl: 'https://raw.githubusercontent.com/bcgov/ckan-ui/pages/pages/about.md',
+                loading: true
             }
         },
-        computed: {
-            ...mapState({
-                userLoading: state => state.user.loading,
-                sysAdmin: state => state.user.sysAdmin,
-            }),
 
-            showEdit: function(){
-                // TODO: IF you aren't overriding the admin functionality like BCDC CKAN does then this is what you want
-                //return ( (!this.editing) && ((this.sysAdmin) || (this.userPermissions[this.dataset.organization.name] === "admin") || (this.userPermissions[this.dataset.organization.name] === "editor")));
-
-                return ( (!this.editing) && (!this.userLoading) && (this.sysAdmin) );
-
-            }
-        },
         mounted() {
             this.getAbout();
             analyticsServ.get(window.currentUrl, this.$route.meta.title, window.previousUrl);
         },
+
         methods: {
-            getAbout(){
-                ckanServ.getAbout().then((data) => {
-                    this.about = data.result;
-                    this.originalAbout = this.about;
-                    this.loading = false;
-                });
+            async getAbout(){
+                this.loading = true;
+                let about = (await ckanServ.getAbout()).content;
+                this.loading = false;
+                this.about = about;
             },
+            
             close(){
                 this.$emit('closeDialog');
-            },
-            updateValues(value){
-                this.about = value;
-            },
-            save(){
-                this.disabled = true;
-                ckanServ.putAbout(this.about).then( (data) => {
-                    if (data.success){
-                        this.formSuccess = true;
-                        this.formError = false;
-                        this.formMessage = "Succesfully updated";
-                        this.editing = false;
-                    }else{
-                        this.formSuccess = false;
-                        this.formError = true;
-                        this.formMessage = "Error updating";
-                    }
-                });
-            },
-            cancel(){
-                this.about = this.originalAbout;
-                this.editing = false;
             }
         }
     }

--- a/frontend/src/services/ckanApi.js
+++ b/frontend/src/services/ckanApi.js
@@ -107,14 +107,23 @@ export class CkanApi {
         return axios.get(url, {withCredentials: true, timeout: apiConfig.timeout}).then(response => response.data);
     }
 
-    getAbout() {
+    async getAbout() {
         const url = '/client-api/ckan/about';
-        return axios.get(url, {withCredentials: true}).then(response => response.data);
-    }
 
-    putAbout(about) {
-        const url = '/client-api/ckan/about';
-        return axios.put(url, {about: about}, {withCredentials: true}).then(response => response.data);
+
+        let aboutPageUrl;
+
+        try {
+            aboutPageUrl = (await axios.get(url, {withCredentials: true})).data.url;
+        } catch (e) {
+            return { content: "" }
+        }
+
+        try {
+            return { content: (await axios.get(aboutPageUrl)).data };
+        } catch (e) {
+            return { content: "" };
+        } 
     }
 
     getDatasetSchema(type) {


### PR DESCRIPTION
Per bcgov#553, removed the dependency on a CKAN API key. The about page is now loaded client side from a configurable URL, currently set to https://raw.githubusercontent.com/bcgov/ckan-ui/pages/pages/about.md.

This required a corresponding helm chart update.