### PR TITLE
Changelog and about page updates, test → beta

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -15,8 +15,12 @@ View [documentation and more information](https://www2.gov.bc.ca/gov/content?id=
 **Dataset Questions:**  
 If you have questions about specific data, please review the Contact section and for ease of use, the Contact Data Expert button at the top of the dataset record.
 
+
+**Technical Support:**  
+For technical support using the catalogue, please email [nrmenquiries@gov.bc.ca](mailto:nrmenquiries@gov.bc.ca).
+
 **Questions about the Catalogue:**  
 If you have general questions about the catalogue, please send us an email at [data@gov.bc.ca](mailto:data@gov.bc.ca).
 
-**Technical Support:**  
-For technical support using the catalogue, please submit a ticket [here](https://apps.nrs.gov.bc.ca/int/jira/servicedesk/customer/portals).
+
+

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -39,7 +39,7 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Description**|**Beta**|**Production**|
 |:---:|:---|:---:|:---:|
-|8|Beta updates deployed based on user feedback and packlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/pages/pages/changelog.md#fixed-issues))|TBD|27-Oct-21|
+|8|Beta updates deployed based on user feedback and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/pages/pages/changelog.md#fixed-issues))|2Oct-21|27-Oct-21|
 |7|Beta updates deployed based on user feedbadk and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/pages/pages/changelog.md#fixed-issues))|05-Oct-21|27-Oct-21|
 |6|Beta updates deployed based on user feedback and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/pages/pages/changelog.md#fixed-issues))|21-Sep-21|27-Oct-21|
 |5|All API keys were regenerated in Beta and will propogate to Production at cutover. **IMPACT**: Your current API keys will not work once we have deployed the new BC Data Catalogue.|08-Sep-21|27-Oct-21|
@@ -52,28 +52,34 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 ### Fixed Issues
 
-|**Issue**|**Release**|
-|:---|:---:|
-|Search sort is now by Relevance and not Newest.|4|
-|All fields and their values have now been directed to the correct destination. Field updates have been reflected in the Field, Label and Value Changes section below.|4|
-|Records for Webservice/API and Application originally now have the date the metadata was created added as a default for the Resource History Lifecycle. Editors may change this to a date they wish.|4|
-|Record and Resource deletion now prompts the user to confirm deletion is desired before deleting item.|4|
-|Resources that are not previewable, the Preview button is greyed out.|4|
-|Resources have been changed to "Access/Download" as was in production Cat Classic.|4|
-|Resource file size limit set to be the same as production Cat Classic.|4|
-|Resource URL for BCGW Custom Download is no longer visible, removing confusion, as it is not accessible.|4| 
-|Page Titles for SEO ([#551](https://github.com/bcgov/ckan-ui/issues/551))|6|
-|Fix logging out to end the session to prompt login ([#542](https://github.com/bcgov/ckan-ui/issues/542))|6|
-|Modifications to Delete popup messaging ([#518](https://github.com/bcgov/ckan-ui/issues/518))|6|
-|New Documentation option under Menu ([#535](https://github.com/bcgov/ckan-ui/issues/535))|6|
-|Remove the follow button from the UI ([#566](https://github.com/bcgov/ckan-ui/issues/566))|7|
-|Remove admin key from UI config ([#553](https://github.com/bcgov/ckan-ui/issues/553))|7|
-|MVP - Update to About Page Text ([#534](https://github.com/bcgov/ckan-ui/issues/534))|7|
-|Delete functionality on Record (aka Dataset/Metadata) and associated Resources ([#519](https://github.com/bcgov/ckan-ui/issues/519))|7|
-|OFI Configuration - unable to configure secure datasets([#501](https://github.com/bcgov/ckan-ui/issues/501))|7|
-|Release 2.0.0-beta.3 Developer Checklist ([#574](https://github.com/bcgov/ckan-ui/issues/574))|7|
-|Dataset Published State - Security Issues and datasets found number oddities ([#468](https://github.com/bcgov/ckan-ui/issues/486))|8|
-|Ministry/Parent Org - abilities Inherited to Suborg/Branch ([#488](https://github.com/bcgov/ckan-ui/issues/488))|8|
+|**Deployment No.**|**Issue**|**Tix No.**|
+|:---:|:---|:---:|
+|8|Dataset Published State - Security Issues and datasets found number oddities| ([#468](https://github.com/bcgov/ckan-ui/issues/486))
+|8|Ministry/Parent Org - abilities Inherited to Suborg/Branch| ([#488](https://github.com/bcgov/ckan-ui/issues/488))
+|8|Secure Groups - Remove visibility from API and UI when logged out| ([#447](https://github.com/bcgov/ckan-ui/issues/447))
+|8|MVP - Filter Search Results Group Facet should not display Private Groups when not logged in| ([#589](https://github.com/bcgov/ckan-ui/issues/589))
+|8|MVP - Update the About text to remove BETA specific instruction under For Technical Support |([#507](https://github.com/bcgov/ckan-ui/issues/507))
+|8|Filter Titles inconsistent with Field Names - Change Filter Titles| ([#546](https://github.com/bcgov/ckan-ui/issues/546))
+|8|Geographic Resources - Resource Type populating with Projection Name| ([#575](https://github.com/bcgov/ckan-ui/issues/575))
+|8|Geospatial Attributes Config Fields to set to Not Visible in View mode| ([#313](https://github.com/bcgov/ckan-ui/issues/313))
+|7|Remove the follow button from the UI| ([#566](https://github.com/bcgov/ckan-ui/issues/566))
+|7|Remove admin key from UI config |([#553](https://github.com/bcgov/ckan-ui/issues/553))
+|7|MVP - Update to About Page Text| ([#534](https://github.com/bcgov/ckan-ui/issues/534))
+|7|Delete functionality on Record (aka Dataset/Metadata) and associated Resources| ([#519](https://github.com/bcgov/ckan-ui/issues/519))
+|7|OFI Configuration - unable to configure secure datasets|([#501](https://github.com/bcgov/ckan-ui/issues/501))
+|7|Release 2.0.0-beta.3 Developer Checklist| ([#574](https://github.com/bcgov/ckan-ui/issues/574))
+|6|Page Titles for SEO| ([#551](https://github.com/bcgov/ckan-ui/issues/551))
+|6|Fix logging out to end the session to prompt login |([#542](https://github.com/bcgov/ckan-ui/issues/542))
+|6|Modifications to Delete popup messaging| ([#518](https://github.com/bcgov/ckan-ui/issues/518))
+|6|New Documentation option under Menu| ([#535](https://github.com/bcgov/ckan-ui/issues/535))
+|4|Search sort is now by Relevance and not Newest.
+|4|All fields and their values have now been directed to the correct destination. Field updates have been reflected in the Field, Label and Value Changes section below.
+|4|Records for Webservice/API and Application originally now have the date the metadata was created added as a default for the Resource History Lifecycle. Editors may change this to a date they wish.
+|4|Record and Resource deletion now prompts the user to confirm deletion is desired before deleting item.
+|4|Resources that are not previewable, the Preview button is greyed out.
+|4|Resources have been changed to "Access/Download" as was in production Cat Classic.
+|4|Resource file size limit set to be the same as production Cat Classic.
+|4|Resource URL for BCGW Custom Download is no longer visible, removing confusion, as it is not accessible.
 
 [RETURN TO TOP][1]
 
@@ -86,7 +92,7 @@ Not all items have been flagged in this list, some are actively being worked on 
 1. Group editors and members management to be configured. 
     + All Group management can only be done by users with Admin access at this time. 
 3. The OpenAPI Console preview function is not available.
-4. The Data Usage page is not available.
+4. The Data Usage page is not yet available.
 5. Resource Update Date is not visible in the UI but via the API. Reviewing best terms to describle what dates this field has.
 6. Domain value lists are inconsistent across the schema in their letter case. We will be implimenting snake_case in the future.
 
@@ -184,16 +190,7 @@ This is also referred to as the package.
 + Values returned from the API are consistently using the field value and not the field label.
 + JSON Schema now available: https://cat.data.gov.bc.ca/api/3/action/scheming_dataset_schema_show?type=bcdc_dataset
 + See [Field, Label and Value Changes](beta_schema_changes.md#field-label-and-value-changes) for changes, including `object_name` having been moved from packages to resources.
-
-**Common queries**:
-1. `object_name`
-    - `object_name` has moved to the resource level, the API query is slightly different as `object_name` is in the resource extras table.
-         + Production: https://catalogue.data.gov.bc.ca/api/3/action/package_search?q=object_name:WHSE_WILDLIFE_MANAGEMENT.WAA_TRAPLINE_AREAS_SP
-         + Beta: https://cat.data.gov.bc.ca/api/3/action/package_search?q=res_extras_object_name:WHSE_WILDLIFE_MANAGEMENT.WAA_TRAPLINE_AREAS_SP
-1. `bcdc_type` (`geographic`, `dataset`, `webservice`, `application`)
-    - `bcdc_type` is now the field that contains the resource type, this was previously `type` at the package level.
-         + Production: https://catalogue.data.gov.bc.ca/api/3/action/package_search?q=type:Geographic
-         + Beta: https://cat.data.gov.bc.ca/api/3/action/package_search?q=res_extras_bcdc_type:geographic
++ See [How to use the API](https://bcgov.github.io/data-publication/pages/dps_bcdc_api_w_how_to_use.html) for common calls and resource and record update examples.
 
 
 [RETURN TO TOP][1]


### PR DESCRIPTION
Some changelog updates were missed in the last deployment. This PR includes those as well as a small update to the about page text.