### PR TITLE
Added option to store sessions in Redis

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -41,10 +41,13 @@ const sessionSettings = {
 
 // use redis for sessions if configured
 if (config.redisHost && config.redisPort) {
-  const redisClient = redis.createClient({
+  const clientConnectConfig = {
       host: config.redisHost,
       port: config.redisPort
-  });
+  };
+  if (config.redisPassword) clientConnectConfig.password = config.redisPassword;
+
+  const redisClient = redis.createClient(clientConnectConfig);
 
   sessionSettings.store = new RedisStore({ client: redisClient })
 }

--- a/backend/app.js
+++ b/backend/app.js
@@ -47,8 +47,6 @@ if (config.redisHost && config.redisPort) {
   });
 
   sessionSettings.store = new RedisStore({ client: redisClient })
-
-  console.log("Set up session store with redis");
 }
 
 app.use(session(sessionSettings));

--- a/backend/config/default.json
+++ b/backend/config/default.json
@@ -7,6 +7,9 @@
   "classicUi": "http://127.0.0.1:5000",
   "aboutPageUrl": "https://raw.githubusercontent.com/bcgov/ckan-ui/pages/pages/about.md",
 
+  "redisHost": null,
+  "redisPort": null,
+
   "oidc": {
     "issuer": "https://{yourdomain}/oauth2/default",
     "authorizationURL": "https://{yourdomain}/oauth2/default/v1/authorize",

--- a/backend/config/default.json
+++ b/backend/config/default.json
@@ -9,6 +9,7 @@
 
   "redisHost": null,
   "redisPort": null,
+  "redisPassword": null,
 
   "oidc": {
     "issuer": "https://{yourdomain}/oauth2/default",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "ckan-ui-bridge",
-  "version": "2.0.0-beta.8",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ckan-ui-bridge",
-      "version": "2.0.0-beta.8",
+      "version": "2.1.0",
       "dependencies": {
         "atob": "^2.1.2",
         "axios": "^0.21.2",
         "btoa": "^1.2.1",
         "config": "^3.0.1",
+        "connect-redis": "^6.0.0",
         "cookie-parser": "~1.4.3",
         "debug": "~2.6.9",
         "express": "~4.16.0",
@@ -24,6 +25,7 @@
         "node-cache": "^4.2.0",
         "passport": "^0.4.0",
         "passport-openidconnect": "0.0.2",
+        "redis": "^3.1.2",
         "request": "^2.88.0",
         "set-value": "^4.0.1",
         "snowplow-tracker": "^0.3.0",
@@ -935,6 +937,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/connect-redis": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-6.0.0.tgz",
+      "integrity": "sha512-6eGEAAPHYvcfbRNCMmPzBIjrqRWLw7at9lCUH4G6NQ8gwWDJelaUmFNOqPIhehbw941euVmIuqWsaWiKXfb+5g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -1087,6 +1097,14 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -2948,6 +2966,48 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "dependencies": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-redis"
+      }
+    },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -4656,6 +4716,11 @@
         "xdg-basedir": "^4.0.0"
       }
     },
+    "connect-redis": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-6.0.0.tgz",
+      "integrity": "sha512-6eGEAAPHYvcfbRNCMmPzBIjrqRWLw7at9lCUH4G6NQ8gwWDJelaUmFNOqPIhehbw941euVmIuqWsaWiKXfb+5g=="
+    },
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -4773,6 +4838,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -6176,6 +6246,35 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "redis": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "requires": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
       }
     },
     "regenerator-runtime": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckan-ui-bridge",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "start": "NODE_ENV=prod node ./bin/www",
@@ -12,6 +12,7 @@
     "axios": "^0.21.2",
     "btoa": "^1.2.1",
     "config": "^3.0.1",
+    "connect-redis": "^6.0.0",
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.9",
     "express": "~4.16.0",
@@ -24,6 +25,7 @@
     "node-cache": "^4.2.0",
     "passport": "^0.4.0",
     "passport-openidconnect": "0.0.2",
+    "redis": "^3.1.2",
     "request": "^2.88.0",
     "set-value": "^4.0.1",
     "snowplow-tracker": "^0.3.0",

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -39,7 +39,7 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Description**|**Beta**|**Production**|
 |:---:|:---|:---:|:---:|
-|11|Beta updates deployed based on user feedback and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/pages/pages/changelog.md#fixed-issues))|29-Oct-21|1-Nov-21|
+|11|Beta updates deployed based on user feedback and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/pages/pages/changelog.md#fixed-issues))|29-Oct-21|5-Nov-21|
 |10|Update to improve catalogue stability (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/pages/pages/changelog.md#fixed-issues))|28-Oct-21|28-Oct-21|
 |9|Beta updates deployed based on user feedback and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/pages/pages/changelog.md#fixed-issues))|21-Oct-21|27-Oct-21|
 |8|Beta updates deployed based on user feedback and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/pages/pages/changelog.md#fixed-issues))|20-Oct-21|27-Oct-21|
@@ -57,6 +57,7 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Issue**|**Tix No.**|
 |:---:|:---|:---:|
+|11|Stability improvements for logged in users| ([#617](https://github.com/bcgov/ckan-ui/pull/617))
 |11|Improvements to search relevance and availability of advanced search features| ([#615](https://github.com/bcgov/ckan-ui/pull/615))
 |11|Improvements to search relevance for mixed case words| ([#614](https://github.com/bcgov/ckan-ui/pull/614))
 |11|Fixed bug where file sizes were represented incorrectly| ([#613](https://github.com/bcgov/ckan-ui/pull/613))


### PR DESCRIPTION
I've added an option to save session information to a redis instance at a user-configurable host and port. This should improve the stability of session state, even in lieu of a HA configuration for Redis, because users won't get logged out every time the backend bridge's container crashes; a Redis pod is likely to be more stable.

New configuration values include:

 - `redisHost`
 - `redisPort`
 - `redisPassword`

Both default to null.