### PR TITLE
Increased memory limit for backend bridge

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.0",
   "private": true,
   "scripts": {
-    "start": "NODE_ENV=prod node ./bin/www",
+    "start": "NODE_ENV=prod node --max-old-space-size=3750 ./bin/www",
     "serve": "NODE_ENV=dev nodemon ./bin/www",
     "lint": "npx eslint ."
   },


### PR DESCRIPTION
I increased the heap size limit for node to 3.75GB to give it a little more room to breath.