### PR TITLE
Removed all_fields=True from organization_list_related API call

### DIFF
--- a/backend/routes/ckan/organizations.js
+++ b/backend/routes/ckan/organizations.js
@@ -61,7 +61,7 @@ var addRoutes = function(router){
         let orgTTL = 86400;
     
         //let keys = Object.keys(req.query);
-        let reqUrl = url + "/api/3/action/organization_list_related?all_fields=True";
+        let reqUrl = url + "/api/3/action/organization_list_related";
     
         let authObj = {};
     


### PR DESCRIPTION
With bcgov/ckanext-bcgov#890, /api/3/action/organization_list_related provides enough information without setting `all_fields` to True, and omitting that parameter makes the API call faster.