### PR TITLE
Use whoami

### DIFF
--- a/backend/routes/ckan/user.js
+++ b/backend/routes/ckan/user.js
@@ -52,9 +52,9 @@ function addRoutes(router) {
             });
 
         });
-    };
+    }
 
     return router;
-};
+}
 
 module.exports = addRoutes;

--- a/backend/routes/ckan/user.js
+++ b/backend/routes/ckan/user.js
@@ -7,16 +7,7 @@ function addRoutes(router) {
     proxyCkanApiRequest("/userOrganizations", (req) => "/api/3/action/organization_list_for_user?id="+encodeURIComponent(req.user._json.preferred_username));
     proxyCkanApiRequest(
         "/activity/:userId",
-        (req) => "/api/3/action/user_activity_list?id=" + encodeURIComponent(req.params.userId),
-        (req, res, next) => {
-            if (typeof(req.params.userId) === 'undefined'){
-                res.status(500);
-                res.json({error: "User ID is required"});
-                return;
-            } else {
-                next();
-            }
-        }
+        (req) => "/api/3/action/user_activity_list?id=" + encodeURIComponent(req.params.userId)
     );
     proxyCkanApiRequest('/user/:userId', (req) => `/api/3/action/user_show?id=${encodeURIComponent(req.params.userId)}&include_datasets=True`);
 

--- a/backend/routes/ckan/user.js
+++ b/backend/routes/ckan/user.js
@@ -25,10 +25,6 @@ function addRoutes(router) {
                         'Authorization': req.user.jwt
                     }
                 };
-            } else {
-                console.log("no user");
-                res.json({ results: [], error: "No user" });
-                return;
             }
 
             let reqUrl;

--- a/backend/routes/ckan/user.js
+++ b/backend/routes/ckan/user.js
@@ -1,165 +1,72 @@
-var addRoutes = function(router){
-    let request = require('request');
-    let auth = require('../../modules/auth');
+const request = require('request');
+const auth = require('../../modules/auth');
 
-    /* GET User Orgs */
-    router.get('/userOrganizations', auth.removeExpired, function(req, res, next) {
-
-        let config = require('config');
-        let url = config.get('ckan');
-
-        let authObj = {};
-
-        if (req.user){
-        authObj = {
-            'headers': {
-            'Authorization': req.user.jwt
+function addRoutes(router) {
+    proxyCkanApiRequest("/whoami", "/api/3/action/whoami");
+    proxyCkanApiRequest("/activity", "/api/3/action/dashboard_activity_list");
+    proxyCkanApiRequest("/userOrganizations", (req) => "/api/3/action/organization_list_for_user?id="+encodeURIComponent(req.user._json.preferred_username));
+    proxyCkanApiRequest(
+        "/activity/:userId",
+        (req) => "/api/3/action/user_activity_list?id=" + encodeURIComponent(req.params.userId),
+        (req, res, next) => {
+            if (typeof(req.params.userId) === 'undefined'){
+                res.status(500);
+                res.json({error: "User ID is required"});
+                return;
+            } else {
+                next();
             }
-        };
-        }else{
-            console.log("no user");
-            res.json({results: [], error: "No user"});
-            return;
         }
+    );
+    proxyCkanApiRequest('/user/:userId', (req) => `/api/3/action/user_show?id=${encodeURIComponent(req.params.userId)}&include_datasets=True`);
 
-        let reqUrl = url + "/api/3/action/organization_list_for_user?id="+req.user._json.preferred_username;
+    function proxyCkanApiRequest(endpoint, upstreamPath, ...middlewares) {
+        router.get(endpoint, auth.removeExpired, ...middlewares, (req, res, next) => {
 
-        request(reqUrl, authObj, function(err, apiRes, body){
-            if (err) {
-                console.log(err);
-                res.json({error: err});
+            let config = require('config');
+            let url = config.get('ckan');
+
+            let authObj = {};
+
+            if (req.user) {
+                authObj = {
+                    'headers': {
+                        'Authorization': req.user.jwt
+                    }
+                };
+            } else {
+                console.log("no user");
+                res.json({ results: [], error: "No user" });
                 return;
             }
 
-            try {
-                let json = JSON.parse(body);
-                res.json(json);
-            }catch(ex){
-                console.error("Error reading json from ckan", ex);
-                res.json({error: ex});
-            }
-        });
+            let reqUrl;
 
-    });
-
-    /* GET user activity. */
-    router.get('/activity', auth.removeExpired, function(req, res, next) {
-        let config = require('config');
-        let url = config.get('ckan');
-
-        let reqUrl = url + "/api/3/action/dashboard_activity_list";
-
-        if (!req.user){
-            return res.json({error: "Not logged in"});
-        }
-
-        let authObj = {
-            'auth': {
-            'bearer': req.user.jwt
-            }
-        };
-
-        request(reqUrl, authObj, function(err, apiRes, body){
-            if (err) {
-                console.log(err);
-                res.json({error: err});
-                return;
-            }
-            if (apiRes.statusCode !== 200){
-                console.log("Body Status? ", apiRes.statusCode);
+            if (typeof upstreamPath === "function") {
+                reqUrl = url + upstreamPath(req);
+            } else {
+                reqUrl = url + upstreamPath;
             }
 
-            try {
-                let json = JSON.parse(body);
-                res.json(json);
-            }catch(ex){
-                console.error("Error reading json from ckan", ex);
-                res.json({error: ex});
-            }
-        });
-
-    });
-
-    /* GET user activity. */
-    router.get('/activity/:userId', auth.removeExpired, function(req, res, next) {
-        let config = require('config');
-        let url = config.get('ckan');
-
-        if (typeof(req.params.userId) === 'undefined'){
-            res.status(500);
-            return res.json({error: "User ID is required"});
-        }
-
-        let reqUrl = url + "/api/3/action/user_activity_list?id=" + req.params.userId;
-
-        let authObj = {}
-
-        if (req.user){
-            authObj = {
-                'auth': {
-                'bearer': req.user.jwt
+            request(reqUrl, authObj, function(err, apiRes, body) {
+                if (err) {
+                    console.log(err);
+                    res.json({error: err});
+                    return;
                 }
-            };
-        }
 
-        request(reqUrl, authObj, function(err, apiRes, body){
-            if (err) {
-                console.log(err);
-                res.json({error: err});
-                return;
-            }
-            if (apiRes.statusCode !== 200){
-                console.log("Body Status? ", apiRes.statusCode);
-            }
-
-            try {
-                let json = JSON.parse(body);
-                res.json(json);
-            }catch(ex){
-                console.error("Error reading json from ckan", ex);
-                res.json({error: ex});
-            }
-        });
-
-    });
-
-    /* GET user info. */
-    router.get('/user/:userId', auth.removeExpired, function(req, res, next) {
-        let config = require('config');
-        let url = config.get('ckan');
-
-        let reqUrl = url + "/api/3/action/user_show?id="+req.params.userId+"&include_datasets=True";
-
-        let authObj = {};
-
-        if (req.user){
-            authObj = {
-                'auth': {
-                'bearer': req.user.jwt
+                try {
+                    let json = JSON.parse(body);
+                    res.json(json);
+                } catch(ex){
+                    console.error("Error reading json from ckan", ex);
+                    res.json({error: ex});
                 }
-            };
-        }
+            });
 
-        request(reqUrl, authObj, function(err, apiRes, body){
-            if (err) {
-                console.log(err);
-                res.json({error: err});
-                return;
-            }
-            if (apiRes.statusCode !== 200){
-                console.log("Body Status? ", apiRes.statusCode);
-            }
-
-            try {
-                let json = JSON.parse(body);
-                res.json(json);
-            }catch(ex){
-                console.error("Error reading json from ckan", ex);
-                res.json({error: ex});
-            }
         });
+    };
 
-    });
     return router;
 };
 

--- a/frontend/src/components/common/activityList.vue
+++ b/frontend/src/components/common/activityList.vue
@@ -1,6 +1,9 @@
 <template>
     <v-container fluid>
-        <v-row wrap v-for="(activityItem, key) in activities" class="pa-0 ma-0" :key="'activity-line'+key">
+        <v-row v-if="!activities.length">
+            No activities yet, get involved!
+        </v-row>
+        <v-row v-else wrap v-for="(activityItem, key) in activities" class="pa-0 ma-0" :key="'activity-line'+key">
             <ActivityItem :activity="activityItem" :article="article"></ActivityItem>
         </v-row>
     </v-container>

--- a/frontend/src/components/pages/user.vue
+++ b/frontend/src/components/pages/user.vue
@@ -20,7 +20,6 @@
           color="grey"
           indeterminate
         ></v-progress-circular>
-        <div v-else-if="noData">No activities yet, get involved!</div>
         <v-row wrap v-else>
             <v-col cols=3>
                 <Profile :user="user"></Profile>
@@ -64,7 +63,6 @@
                 ],
                 user: {},
                 user_id: this.$route.params.userId ? this.$route.params.userId : "",
-                noData: false,
             }
         },
         computed:{
@@ -73,17 +71,17 @@
             }
         },
         methods: {
-            getUserActivity: function(){
+            getUserActivity: async function(){
+
+                this.user_id = await ckanServ.getUserId() || null;
+
+                this.getUser();
+
                 ckanServ.getActivity(this.user_id).then( (data) => {
                     if (data.error){
                         this.error = data.error;
-                    } else if ( (typeof(data.result) == "undefined") || (typeof(data.result[0]) === "undefined") ||  (typeof(data.result[0].user_id) === "undefined") ){
-                        this.noData = true;
                     } else {
-
                         this.activities = data.result;
-                        this.user_id = data.result[0].user_id
-                        this.getUser()
                     }
                     this.loading = false;
                 });

--- a/frontend/src/services/ckanApi.js
+++ b/frontend/src/services/ckanApi.js
@@ -72,6 +72,11 @@ export class CkanApi {
         return axios.get(url, {withCredentials: true}).then(response => response.data);
     }
 
+    getUserId() {
+        const url = '/client-api/ckan/whoami';
+        return axios.get(url, {withCredentials: true}).then(response => response.data.result);
+    }
+
     getUser(user_id) {
         const url = '/client-api/ckan/user/'+user_id;
         return axios.get(url, {withCredentials: true}).then(response => response.data);

--- a/frontend/src/store/modules/user.js
+++ b/frontend/src/store/modules/user.js
@@ -78,16 +78,7 @@ const actions = {
             isEditor = false;
         }
 
-        ckanServ.getActivity(this.user_id).then( (d) => {
-            if ( (d.result) && (d.result[0]) && (d.result[0]) && (d.result[0].user_id) ){
-                ckanServ.getUser(d.result[0].user_id).then( (data) => {
-                    commit('setCkanUser', {ckanUser: data.result});
-                });
-            }else{
-                commit('setCkanUser', {ckanUser: null});
-            }
-        });
-
+        commit('setCkanUser', {ckanUser: await ckanServ.getUserId() || null});
         commit('setUserPermissions', {userPermissions: userPermissions});
         commit('setSysAdmin', {sysAdmin: sysAdmin});
         commit('setAdmin', {isAdmin: isAdmin});


### PR DESCRIPTION
Updated the user profile page to identify the current user via the newly minted whoami API call. The allows users without activity history to view their profile and retrieve their API key, as it no longer uses a heuristic that depends on activity history items.