### PR TITLE
Up timeout to 15seconds

### DIFF
--- a/frontend/src/services/apiConfig.js
+++ b/frontend/src/services/apiConfig.js
@@ -1,4 +1,4 @@
 export default 
 {
-    "timeout": 10000
+    "timeout": 15000
 }


### PR DESCRIPTION
Not just an issue with loading /groups page but also loading individual groups.