### PR TITLE
Update groups page api calls

### DIFF
--- a/frontend/src/components/groups/GroupCard.vue
+++ b/frontend/src/components/groups/GroupCard.vue
@@ -32,8 +32,7 @@
 </template>
 
 <script>
-import {CkanApi} from '../../services/ckanApi'
-const ckanServ = new CkanApi()
+
 
 export default{
     name: 'GroupCard',
@@ -72,15 +71,6 @@ export default{
       },
 
     },
-
-    mounted() {
-      ckanServ.getGroup(this.id).then((data) => {
-
-        this.datasets = data.result.packages;
-
-        this.loading = false;
-      });
-    }
 
 }
 </script>

--- a/frontend/src/components/pages/groups.vue
+++ b/frontend/src/components/pages/groups.vue
@@ -139,6 +139,9 @@
 
     import Edit from '../groups/edit'
 
+    import {CkanApi} from '../../services/ckanApi'
+    const ckanServ = new CkanApi()
+
     export default {
         name: "groups",
         components: {
@@ -165,6 +168,21 @@
             analyticsServ.get(window.currentUrl, this.$route.meta.title, window.previousUrl);
             this.$store.dispatch('group/getGroups');
             this.count = this.groups.length;
+
+            let index = 0;
+
+            let groupData = function(data) {
+                this.groups[index].datasets = data.result.packages;
+                this.groups[index].loading = false;
+                index++;
+
+                if (index < this.groups.length) {
+                    ckanServ.getGroup(this.groups[index].id).then(data => groupData(data))
+                }
+            }
+
+            ckanServ.getGroup(this.groups[index].id).then(data => groupData(data))
+
         },
 
         watch: {


### PR DESCRIPTION
Update groups page api calls to execute sequentially and not all at once to avoid api bottleneck and calls timing out.

- moved api call from GroupCard to groups page
- loop through group api calls, waiting on each promise to resolve before calling the next