### PR TITLE
Fix group(s) page loading

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckan-ui-bridge",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "private": true,
   "scripts": {
     "start": "NODE_ENV=prod node ./bin/www",

--- a/frontend/src/components/groups/GroupCard.vue
+++ b/frontend/src/components/groups/GroupCard.vue
@@ -20,7 +20,12 @@
                 <span class="groupName">{{name}}</span>
                 </v-row>
                 <v-row dense>
-                <p class="groupCount">{{datasets.length}} {{$tc('datasets', datasets.length)}}</p>
+                <v-progress-circular
+                    v-if="loading"
+                    indeterminate
+                    color="light-blue"
+                ></v-progress-circular>
+                <p v-else class="groupCount">{{datasets.length}} {{$tc('datasets', datasets.length)}}</p>
                 </v-row>
               </v-container>
           </v-col>

--- a/frontend/src/components/groups/GroupCard.vue
+++ b/frontend/src/components/groups/GroupCard.vue
@@ -20,11 +20,14 @@
                 <span class="groupName">{{name}}</span>
                 </v-row>
                 <v-row dense>
-                <v-progress-circular
-                    v-if="loading"
+                <p v-if="loading">
+                  <v-progress-circular
+                    :size="20"
+                    :width="2"
                     indeterminate
                     color="light-blue"
-                ></v-progress-circular>
+                  ></v-progress-circular>
+                </p>
                 <p v-else class="groupCount">{{datasets.length}} {{$tc('datasets', datasets.length)}}</p>
                 </v-row>
               </v-container>

--- a/frontend/src/components/groups/GroupCard.vue
+++ b/frontend/src/components/groups/GroupCard.vue
@@ -59,6 +59,13 @@ export default{
         }
     },
 
+    watch: {
+      group(newData) {
+        this.datasets = newData.datasets;
+        this.loading = newData.loading;
+      }
+    },
+
     computed: {
       image: function(){
         return !this.imageError ? (this.group.image_display_url ? this.group.image_display_url : this.group.url) : '/placeholder-organization.png';

--- a/frontend/src/components/groups/GroupCard.vue
+++ b/frontend/src/components/groups/GroupCard.vue
@@ -32,8 +32,7 @@
 </template>
 
 <script>
-import {CkanApi} from '../../services/ckanApi'
-const ckanServ = new CkanApi()
+
 
 export default{
     name: 'GroupCard',
@@ -75,15 +74,6 @@ export default{
     updated() {
         window.snowplow('refreshLinkClickTracking');
     },
-
-    mounted() {
-      ckanServ.getGroup(this.id).then((data) => {
-
-        this.datasets = data.result.packages;
-
-        this.loading = false;
-      });
-    }
 
 }
 </script>

--- a/frontend/src/components/pages/groups.vue
+++ b/frontend/src/components/pages/groups.vue
@@ -183,8 +183,9 @@
                 // eslint-disable-next-line
                 console.log(data);
 
-                self.groups[index].datasets = data.result.packages;
-                self.groups[index].loading = false;
+                Vue.set(self.groups[index], 'datasets', data.result.packages);
+                Vue.set(self.groups[index], 'loading', false);
+                
                 index++;
 
                 if (index < self.groups.length) {

--- a/frontend/src/components/pages/groups.vue
+++ b/frontend/src/components/pages/groups.vue
@@ -171,17 +171,28 @@
 
             let index = 0;
 
+            // eslint-disable-next-line
+            console.log(this.groups);
+
+            var self = this;
+
             let groupData = function(data) {
-                this.groups[index].datasets = data.result.packages;
-                this.groups[index].loading = false;
+
+                // eslint-disable-next-line
+                console.log(self.groups);
+                // eslint-disable-next-line
+                console.log(data);
+
+                self.groups[index].datasets = data.result.packages;
+                self.groups[index].loading = false;
                 index++;
 
-                if (index < this.groups.length) {
-                    ckanServ.getGroup(this.groups[index].id).then(data => groupData(data))
+                if (index < self.groups.length) {
+                    ckanServ.getGroup(self.groups[index].id).then(data => groupData(data))
                 }
             }
 
-            ckanServ.getGroup(this.groups[index].id).then(data => groupData(data))
+            ckanServ.getGroup(self.groups[index].id).then(data => groupData(data))
 
         },
 

--- a/frontend/src/components/pages/groups.vue
+++ b/frontend/src/components/pages/groups.vue
@@ -173,18 +173,9 @@
 
             let index = 0;
 
-            // eslint-disable-next-line
-            console.log(this.groups);
-
             var self = this;
 
             let groupData = function(data) {
-
-                // eslint-disable-next-line
-                console.log(self.groups);
-                // eslint-disable-next-line
-                console.log(data);
-
                 Vue.set(self.groups[index], 'datasets', data.result.packages);
                 Vue.set(self.groups[index], 'loading', false);
                 
@@ -196,7 +187,6 @@
             }
 
             ckanServ.getGroup(self.groups[index].id).then(data => groupData(data))
-
         },
 
         watch: {

--- a/frontend/src/components/pages/groups.vue
+++ b/frontend/src/components/pages/groups.vue
@@ -142,6 +142,8 @@
     import {CkanApi} from '../../services/ckanApi'
     const ckanServ = new CkanApi()
 
+    import Vue from 'vue'
+
     export default {
         name: "groups",
         components: {

--- a/frontend/src/components/pages/groups.vue
+++ b/frontend/src/components/pages/groups.vue
@@ -139,6 +139,9 @@
 
     import Edit from '../groups/edit'
 
+    import {CkanApi} from '../../services/ckanApi'
+    const ckanServ = new CkanApi()
+
     export default {
         name: "groups",
         components: {
@@ -165,6 +168,21 @@
             analyticsServ.get(window.currentUrl, this.$route.meta.title, window.previousUrl);
             this.$store.dispatch('group/getGroups');
             this.count = this.groups.length;
+
+            let index = 0;
+
+            let groupData = function(data) {
+                this.groups[index].datasets = data.result.packages;
+                this.groups[index].loading = false;
+                index++;
+
+                if (index < this.groups.length) {
+                    ckanServ.getGroup(this.groups[index].id).then(data => groupData(data))
+                }
+            }
+
+            ckanServ.getGroup(this.groups[index].id).then(data => groupData(data))
+
         },
 
         watch: {

--- a/frontend/src/services/apiConfig.js
+++ b/frontend/src/services/apiConfig.js
@@ -1,4 +1,4 @@
 export default 
 {
-    "timeout": 10000
+    "timeout": 15000
 }

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -39,7 +39,8 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Description**|**Beta**|**Production**|
 |:---:|:---|:---:|:---:|
-|14|Enable snowplow analytics to be captured (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|07-Jan-22||
+|15|Fix loading of groups page (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|26-Jan-22||
+|14|Enable snowplow analytics to be captured (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|07-Jan-22|26-Jan-22|
 |13|Update to enable exclamation marks and commas in URLs (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|08-Dec-21|12-Jan-22|
 |12|Updates deployed based on user feedback and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|23-Nov-21|30-Nov-21|
 |11|Beta updates deployed based on user feedback and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|29-Oct-21|5-Nov-21|
@@ -60,6 +61,8 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Issue**|**Tix No.**|
 |:---:|:---|:---:|
+|15|Update GroupCards with new value| ([#688](https://github.com/bcgov/ckan-ui/pull/688))
+|15|Loop group API calls| ([#670](https://github.com/bcgov/ckan-ui/pull/670))
 |14|Enable link click tracking| ([#662](https://github.com/bcgov/ckan-ui/pull/662), [#664](https://github.com/bcgov/ckan-ui/pull/664))
 |14|Add snowplow frontend script| ([#641](https://github.com/bcgov/ckan-ui/pull/641))
 |13|Allow commas (,) in URL regex| ([#651](https://github.com/bcgov/ckan-ui/pull/651))


### PR DESCRIPTION
For the groups page:
- move the api call from the GroupCard into the groups page
- wait for each api call to finish before running the next, preventing server overload/call timeouts
- add spinner to indicate loading

For the group pages:
- increase the api call timeout time (this is a temporary fix/bandaid while we look into why these calls take so long/rewrite them on the api side for improved efficiency)