### PR TITLE
Release/2.1.4

### DIFF
--- a/backend/config/default.json
+++ b/backend/config/default.json
@@ -56,7 +56,8 @@
       "collector": "snowPlowCollectorUrl",
       "protocol": "http",
       "port": 8080,
-      "appId": "ckan"
+      "appId": "ckan",
+      "namespace": "catalogue"
   },
 
   "authGroupSeperator": "/",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "ckan-ui-bridge",
-  "version": "2.1.0",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ckan-ui-bridge",
-      "version": "2.1.0",
+      "version": "2.1.3",
       "dependencies": {
+        "@snowplow/node-tracker": "^3.1.6",
         "atob": "^2.1.2",
         "axios": "^0.21.2",
         "btoa": "^1.2.1",
@@ -28,7 +29,6 @@
         "redis": "^3.1.2",
         "request": "^2.88.0",
         "set-value": "^4.0.1",
-        "snowplow-tracker": "^0.3.0",
         "tableschema": "^1.12.4",
         "xlsx": "^0.17.0"
       },
@@ -187,6 +187,183 @@
         "node": ">=6"
       }
     },
+    "node_modules/@snowplow/node-tracker": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@snowplow/node-tracker/-/node-tracker-3.1.6.tgz",
+      "integrity": "sha512-+l/FpZmziktuf4gClz1r2ln35fFPV4LAI4bWRsVt/zHtTy89muZaF1Sl73mUl6b52BbwsEY8pAFkNYX4glGV2Q==",
+      "dependencies": {
+        "@snowplow/tracker-core": "3.1.6",
+        "got": "^11.7.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/@sindresorhus/is": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
+      "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/cacheable-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/got": {
+      "version": "11.8.3",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
+      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/keyv": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
+      "integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snowplow/node-tracker/node_modules/responselike": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      }
+    },
+    "node_modules/@snowplow/tracker-core": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@snowplow/tracker-core/-/tracker-core-3.1.6.tgz",
+      "integrity": "sha512-b2O1xXEqQRzuhIol+3mhk9Xvz/smiW+6pQ3W1fVWonXrYoKtTyak2K+98phj2e0V+H/jUXeviH8adLEdbRkCYA==",
+      "dependencies": {
+        "tslib": "^2.3.0",
+        "uuid": "^3.4.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -199,6 +376,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+      "integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
     "node_modules/@types/csv-parse": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/csv-parse/-/csv-parse-1.2.2.tgz",
@@ -206,6 +394,32 @@
       "deprecated": "This is a stub types definition. csv-parse provides its own type definitions, so you do not need this installed.",
       "dependencies": {
         "csv-parse": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
+      "integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "16.11.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
+      "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw=="
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/abbrev": {
@@ -648,6 +862,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
     "node_modules/cacheable-request": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
@@ -847,7 +1069,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "dev": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
       }
@@ -1182,7 +1403,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -1913,8 +2133,7 @@
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-      "dev": true
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "node_modules/http-errors": {
       "version": "1.6.3",
@@ -1942,6 +2161,18 @@
       "engines": {
         "node": ">=0.8",
         "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -2424,7 +2655,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -2634,7 +2864,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2853,7 +3082,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -2885,6 +3113,17 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/random-bytes": {
@@ -3088,6 +3327,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3307,31 +3551,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/snowplow-tracker": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/snowplow-tracker/-/snowplow-tracker-0.3.0.tgz",
-      "integrity": "sha1-8PsWOm4IilDy+wManjFLZKJQz6Y=",
-      "deprecated": "The snowplow-tracker package is now deprecated. Please switch to @snowplow/node-tracker",
-      "dependencies": {
-        "request": "^2.81.0",
-        "snowplow-tracker-core": "^0.5.0"
-      }
-    },
-    "node_modules/snowplow-tracker-core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/snowplow-tracker-core/-/snowplow-tracker-core-0.5.0.tgz",
-      "integrity": "sha1-Bnx1iQKmdubYtJX+/FC0+h4kfIQ=",
-      "deprecated": "The snowplow-tracker-core package is now deprecated. Please switch to @snowplow/tracker-core",
-      "dependencies": {
-        "uuid": "2.0.3"
-      }
-    },
-    "node_modules/snowplow-tracker-core/node_modules/uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details."
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -3606,6 +3825,11 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3954,8 +4178,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -4139,6 +4362,134 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@snowplow/node-tracker": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@snowplow/node-tracker/-/node-tracker-3.1.6.tgz",
+      "integrity": "sha512-+l/FpZmziktuf4gClz1r2ln35fFPV4LAI4bWRsVt/zHtTy89muZaF1Sl73mUl6b52BbwsEY8pAFkNYX4glGV2Q==",
+      "requires": {
+        "@snowplow/tracker-core": "3.1.6",
+        "got": "^11.7.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@sindresorhus/is": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
+          "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
+        },
+        "@szmarczak/http-timer": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+          "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+          "requires": {
+            "defer-to-connect": "^2.0.0"
+          }
+        },
+        "cacheable-request": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+          "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+          "requires": {
+            "clone-response": "^1.0.2",
+            "get-stream": "^5.1.0",
+            "http-cache-semantics": "^4.0.0",
+            "keyv": "^4.0.0",
+            "lowercase-keys": "^2.0.0",
+            "normalize-url": "^6.0.1",
+            "responselike": "^2.0.0"
+          }
+        },
+        "decompress-response": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "defer-to-connect": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+          "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "got": {
+          "version": "11.8.3",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
+          "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+          "requires": {
+            "@sindresorhus/is": "^4.0.0",
+            "@szmarczak/http-timer": "^4.0.5",
+            "@types/cacheable-request": "^6.0.1",
+            "@types/responselike": "^1.0.0",
+            "cacheable-lookup": "^5.0.3",
+            "cacheable-request": "^7.0.2",
+            "decompress-response": "^6.0.0",
+            "http2-wrapper": "^1.0.0-beta.5.2",
+            "lowercase-keys": "^2.0.0",
+            "p-cancelable": "^2.0.0",
+            "responselike": "^2.0.0"
+          }
+        },
+        "json-buffer": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+        },
+        "keyv": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
+          "integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
+          "requires": {
+            "json-buffer": "3.0.1"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        },
+        "normalize-url": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+          "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+        },
+        "p-cancelable": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+          "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+        },
+        "responselike": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+          "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+          "requires": {
+            "lowercase-keys": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@snowplow/tracker-core": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@snowplow/tracker-core/-/tracker-core-3.1.6.tgz",
+      "integrity": "sha512-b2O1xXEqQRzuhIol+3mhk9Xvz/smiW+6pQ3W1fVWonXrYoKtTyak2K+98phj2e0V+H/jUXeviH8adLEdbRkCYA==",
+      "requires": {
+        "tslib": "^2.3.0",
+        "uuid": "^3.4.0"
+      }
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -4148,12 +4499,49 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/cacheable-request": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+      "integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
     "@types/csv-parse": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/csv-parse/-/csv-parse-1.2.2.tgz",
       "integrity": "sha512-k33tLtRKTQxf7hQfMlkWoS2TQYsnpk1ibZN+rzbuCkeBs8m23nHTeDTF1wb/e7/MSLdtgCzqu3oM1I101kd6yw==",
       "requires": {
         "csv-parse": "*"
+      }
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "@types/keyv": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
+      "integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "16.11.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
+      "integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw=="
+    },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "abbrev": {
@@ -4492,6 +4880,11 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
+    "cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+    },
     "cacheable-request": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
@@ -4639,7 +5032,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -4907,7 +5299,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -5448,8 +5839,7 @@
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-      "dev": true
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "http-errors": {
       "version": "1.6.3",
@@ -5470,6 +5860,15 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
       }
     },
     "iconv-lite": {
@@ -5842,8 +6241,7 @@
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -5999,7 +6397,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6163,7 +6560,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6187,6 +6583,11 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -6338,6 +6739,11 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
+    },
+    "resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -6503,30 +6909,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        }
-      }
-    },
-    "snowplow-tracker": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/snowplow-tracker/-/snowplow-tracker-0.3.0.tgz",
-      "integrity": "sha1-8PsWOm4IilDy+wManjFLZKJQz6Y=",
-      "requires": {
-        "request": "^2.81.0",
-        "snowplow-tracker-core": "^0.5.0"
-      }
-    },
-    "snowplow-tracker-core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/snowplow-tracker-core/-/snowplow-tracker-core-0.5.0.tgz",
-      "integrity": "sha1-Bnx1iQKmdubYtJX+/FC0+h4kfIQ=",
-      "requires": {
-        "uuid": "2.0.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
         }
       }
     },
@@ -6738,6 +7120,11 @@
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
       }
+    },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -6997,8 +7384,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "lint": "npx eslint ."
   },
   "dependencies": {
+    "@snowplow/node-tracker": "^3.1.6",
     "atob": "^2.1.2",
     "axios": "^0.21.2",
     "btoa": "^1.2.1",
@@ -28,7 +29,6 @@
     "redis": "^3.1.2",
     "request": "^2.88.0",
     "set-value": "^4.0.1",
-    "snowplow-tracker": "^0.3.0",
     "tableschema": "^1.12.4",
     "xlsx": "^0.17.0"
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckan-ui-bridge",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "private": true,
   "scripts": {
     "start": "NODE_ENV=prod node ./bin/www",

--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -1,10 +1,10 @@
 let express = require('express');
 let router = express.Router();
 let auth = require('../modules/auth');
-let snowplow = require('snowplow-tracker');
+let snowplow = require('@snowplow/node-tracker');
 let config = require('config');
 
-router .get('/ga', auth.removeExpired, function(req, res){
+router.get('/ga', auth.removeExpired, function(req, res){
     if (!config.has('ga')){
         res.json({"notOk": "Not Configured"});
         return;
@@ -36,66 +36,62 @@ router.get('/', auth.removeExpired, function(req, res){
         return;
     }
 
-    const emitter = snowplow.emitter;
+    const gotEmitter = snowplow.gotEmitter;
     const tracker = snowplow.tracker;
 
     const snowConfig = config.get('snowplow');
 
-    const e = emitter(
+    const e = gotEmitter(
         snowConfig.collector, // Collector endpoint
         snowConfig.protocol, // Optionally specify a method - http is the default
         snowConfig.port, // Optionally specify a port
         "GET", // Method - defaults to GET
-        1,
-        function (error, body, response) { // Callback called for each request
-            if (error) {
-                console.log("Request to Scala Stream Collector failed!");
-                }
-            },
-        { maxSockets: 6 } // Node.js agentOptions object to tune performance
+        1
     );
 
-    let t = tracker([e], snowConfig.appId);
+    let t = tracker([e], snowConfig.namespace, snowConfig.appId, false);
 
     if ((req.user) && (req.user.id)){
         t.setUserId(req.user.id);
     }
 
-
-
-    t.trackPageView(req.query.pageUrl, req.query.pageTitle, req.query.referrer, null);
+    t.track(snowplow.buildPageView(req.query.pageUrl, req.query.pageTitle, req.query.referrer));
 
     res.json({"ok": "ok"});
 });
 
 router.post('/', auth.removeExpired, function(req, res){
 
-    const emitter = snowplow.emitter;
+    if (!config.has('snowplow')){
+        res.json({"notOk": "Not Configured"});
+        return;
+    }
+
+    if ( (!config.has('snowplow.enabled')) || (!config.get('snowplow.enabled')) ){
+        res.json({"notOk": "Not Enabled"});
+        return;
+    }
+
+    const gotEmitter = snowplow.gotEmitter;
     const tracker = snowplow.tracker;
 
     const snowConfig = config.get('snowplow');
 
-    const e = emitter(
+    const e = gotEmitter(
         snowConfig.collector, // Collector endpoint
         snowConfig.protocol, // Optionally specify a method - http is the default
         snowConfig.port, // Optionally specify a port
         "POST", // Method - defaults to GET
-        1,
-        function (error, body, response) { // Callback called for each request
-            if (error) {
-                console.log("Request to Scala Stream Collector failed!");
-                }
-            },
-        { maxSockets: 6 } // Node.js agentOptions object to tune performance
+        1
     );
 
-    let t = tracker([e], snowConfig.appId);
+    let t = tracker([e], snowConfig.namespace, snowConfig.appId, false);
 
     if ((req.user) && (req.user.id)){
         t.setUserId(req.user.id);
     }
 
-    t.trackPageView(req.query.pageUrl, req.query.pageTitle, req.query.referrer, null);
+    t.track(snowplow.buildPageView(req.query.pageUrl, req.query.pageTitle, req.query.referrer));
 
     res.json({"ok": "ok"});
 });

--- a/frontend/src/components/banner/Banner.vue
+++ b/frontend/src/components/banner/Banner.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-banner v-if="message" :color="colour" class="mx-md-n11 px-md-11 mt-n3" icon="mdi-information" elevation=0 tile single-line>
+      {{message}}
+      <template v-if="action" v-slot:actions>
+          <v-btn :color="colour == 'banner_error' ? 'error' : 'secondary'" 
+              :href="action" tile class="white--text" target="_blank">
+            {{actionText}}
+          </v-btn>
+      </template>
+  </v-banner>
+</template>
+
+<script>
+export default {
+    data() {
+      return {
+        message: 'We welcome your feedback! Help us improve your experience by taking our short 1 minute survey.',
+        action: 'https://form.simplesurvey.com/f/s.aspx?s=8d6269f2-2eb0-4dff-86af-09889bda98fe',
+        actionText: 'Give Feedback',
+        colour: 'banner_info' // RED: banner_error, YELLOW: banner_warning, BLUE: banner_info
+      }
+    },
+}
+</script>
+
+<style>
+  .v-banner__wrapper {
+    border-bottom: none !important;
+  }
+</style>

--- a/frontend/src/components/groups/GroupCard.vue
+++ b/frontend/src/components/groups/GroupCard.vue
@@ -20,7 +20,15 @@
                 <span class="groupName">{{name}}</span>
                 </v-row>
                 <v-row dense>
-                <p class="groupCount">{{datasets.length}} {{$tc('datasets', datasets.length)}}</p>
+                <p v-if="loading">
+                  <v-progress-circular
+                    :size="20"
+                    :width="2"
+                    indeterminate
+                    color="light-blue"
+                  ></v-progress-circular>
+                </p>
+                <p v-else class="groupCount">{{datasets.length}} {{$tc('datasets', datasets.length)}}</p>
                 </v-row>
               </v-container>
           </v-col>
@@ -32,8 +40,7 @@
 </template>
 
 <script>
-import {CkanApi} from '../../services/ckanApi'
-const ckanServ = new CkanApi()
+
 
 export default{
     name: 'GroupCard',
@@ -53,6 +60,13 @@ export default{
             loading: true,
             imageError: false
         }
+    },
+
+    watch: {
+      group(newData) {
+        this.datasets = newData.datasets;
+        this.loading = newData.loading;
+      }
     },
 
     computed: {
@@ -75,15 +89,6 @@ export default{
     updated() {
         window.snowplow('refreshLinkClickTracking');
     },
-
-    mounted() {
-      ckanServ.getGroup(this.id).then((data) => {
-
-        this.datasets = data.result.packages;
-
-        this.loading = false;
-      });
-    }
 
 }
 </script>

--- a/frontend/src/components/groups/GroupCard.vue
+++ b/frontend/src/components/groups/GroupCard.vue
@@ -19,7 +19,7 @@
                 <v-row dense>
                 <span class="groupName">{{name}}</span>
                 </v-row>
-                <v-row dense>
+                <!-- <v-row dense>
                 <p v-if="loading">
                   <v-progress-circular
                     :size="20"
@@ -29,7 +29,7 @@
                   ></v-progress-circular>
                 </p>
                 <p v-else class="groupCount">{{datasets.length}} {{$tc('datasets', datasets.length)}}</p>
-                </v-row>
+                </v-row> -->
               </v-container>
           </v-col>
           <v-col cols=1 class="text-right pr-3" align-self="center">

--- a/frontend/src/components/pages/dataset_view.vue
+++ b/frontend/src/components/pages/dataset_view.vue
@@ -145,6 +145,7 @@
                 <v-btn v-if="editing" depressed color="primary" type="submit" @click="submit">{{$tc('Save')}}</v-btn>
             </v-col>
         </v-row>
+        <Banner></Banner>
         
         <v-snackbar v-model="snackbar" :timeout=3000 ><span class="mx-auto permalink">{{$tc('Permalink URL Copied to Clipboard')}}</span></v-snackbar>
 
@@ -214,6 +215,7 @@ import Vue from 'vue';
 import { mapState, mapGetters } from "vuex";
 import { ValidationObserver } from "vee-validate";
 import ResourceList from "../dataset/ResourceList";
+import Banner from '../banner/Banner'
 
 import {Analytics} from '../../services/analytics';
 const analyticsServ = new Analytics()
@@ -232,7 +234,8 @@ export default {
         DynamicForm: DynamicForm,
         ResourceList: ResourceList,
         ValidationObserver: ValidationObserver,
-        DeleteButton
+        DeleteButton,
+        Banner: Banner
     },
     data() {
         let schemaName = 'bcdc_dataset';

--- a/frontend/src/components/pages/datasets.vue
+++ b/frontend/src/components/pages/datasets.vue
@@ -6,6 +6,7 @@
         </div>
     </v-container>
     <v-container fluid v-else class="px-md-11 main-area">
+        <Banner></Banner>
         <v-row wrap class="mr-md-1">
             <v-col cols=10 sm=7>
                 <ListPage
@@ -31,12 +32,13 @@
 
   import ListPage from '../dataset/ListPage'
   import FacetFilters from '../dataset/FacetFilters'
+  import Banner from '../banner/Banner'
 
   export default {
     components: {
         ListPage: ListPage,
-        FacetFilters: FacetFilters
-
+        FacetFilters: FacetFilters,
+        Banner: Banner
     },
 
     data() {

--- a/frontend/src/components/pages/group.vue
+++ b/frontend/src/components/pages/group.vue
@@ -6,6 +6,7 @@
         </div>
     </v-container>
     <v-container v-else fluid class="groupContainer px-md-11 py-4">
+        <Banner></Banner>
         <v-row wrap class="mt-0 px-md-15 py-4 fauxbar">
             <v-col cols=10 class="my-0 py-0" v-if="showFormError || showFormSuccess || group.state === 'deleted'">
                 <v-alert
@@ -134,6 +135,7 @@
     import MemberList from '../groups/MemberList';
     import Markdown from '../form/components/Markdown';
     import Edit from '../groups/edit';
+    import Banner from '../banner/Banner'
 
     import { mapState } from 'vuex';
 
@@ -153,6 +155,7 @@
             MemberList: MemberList,
             Markdown: Markdown,
             Edit: Edit,
+            Banner: Banner
         },
         data () {
             return {

--- a/frontend/src/components/pages/groups.vue
+++ b/frontend/src/components/pages/groups.vue
@@ -168,7 +168,7 @@
         },
         async mounted() {
             analyticsServ.get(window.currentUrl, this.$route.meta.title, window.previousUrl);
-            this.$store.dispatch('group/getGroups');
+            await this.$store.dispatch('group/getGroups');
             this.count = this.groups.length;
 
             let index = 0;

--- a/frontend/src/components/pages/groups.vue
+++ b/frontend/src/components/pages/groups.vue
@@ -166,7 +166,7 @@
                 showFormSuccess: false,
             }
         },
-        mounted() {
+        async mounted() {
             analyticsServ.get(window.currentUrl, this.$route.meta.title, window.previousUrl);
             this.$store.dispatch('group/getGroups');
             this.count = this.groups.length;

--- a/frontend/src/components/pages/groups.vue
+++ b/frontend/src/components/pages/groups.vue
@@ -6,6 +6,7 @@
         </div>
     </v-container>
     <v-container v-else fluid class="groupContainer px-md-11 py-4">
+        <Banner></Banner>
         <v-alert
             :value="showFormSuccess"
             class="fixed"
@@ -138,17 +139,19 @@
     const analyticsServ = new Analytics()
 
     import Edit from '../groups/edit'
+    import Banner from '../banner/Banner'
 
-    import {CkanApi} from '../../services/ckanApi'
-    const ckanServ = new CkanApi()
+    // import {CkanApi} from '../../services/ckanApi'
+    // const ckanServ = new CkanApi()
 
-    import Vue from 'vue'
+    // import Vue from 'vue'
 
     export default {
         name: "groups",
         components: {
             GroupCard: GroupCard,
             Edit: Edit,
+            Banner: Banner
         },
 
         data() {
@@ -171,22 +174,22 @@
             await this.$store.dispatch('group/getGroups');
             this.count = this.groups.length;
 
-            let index = 0;
+            // let index = 0;
 
-            var self = this;
+            // var self = this;
 
-            let groupData = function(data) {
-                Vue.set(self.groups[index], 'datasets', data.result.packages);
-                Vue.set(self.groups[index], 'loading', false);
+            // let groupData = function(data) {
+            //     Vue.set(self.groups[index], 'datasets', data.result.packages);
+            //     Vue.set(self.groups[index], 'loading', false);
                 
-                index++;
+            //     index++;
 
-                if (index < self.groups.length) {
-                    ckanServ.getGroup(self.groups[index].id).then(data => groupData(data))
-                }
-            }
+            //     if (index < self.groups.length) {
+            //         ckanServ.getGroup(self.groups[index].id).then(data => groupData(data))
+            //     }
+            // }
 
-            ckanServ.getGroup(self.groups[index].id).then(data => groupData(data))
+            // ckanServ.getGroup(self.groups[index].id).then(data => groupData(data))
         },
 
         watch: {

--- a/frontend/src/components/pages/groups.vue
+++ b/frontend/src/components/pages/groups.vue
@@ -139,6 +139,11 @@
 
     import Edit from '../groups/edit'
 
+    import {CkanApi} from '../../services/ckanApi'
+    const ckanServ = new CkanApi()
+
+    import Vue from 'vue'
+
     export default {
         name: "groups",
         components: {
@@ -165,6 +170,23 @@
             analyticsServ.get(window.currentUrl, this.$route.meta.title, window.previousUrl);
             this.$store.dispatch('group/getGroups');
             this.count = this.groups.length;
+
+            let index = 0;
+
+            var self = this;
+
+            let groupData = function(data) {
+                Vue.set(self.groups[index], 'datasets', data.result.packages);
+                Vue.set(self.groups[index], 'loading', false);
+                
+                index++;
+
+                if (index < self.groups.length) {
+                    ckanServ.getGroup(self.groups[index].id).then(data => groupData(data))
+                }
+            }
+
+            ckanServ.getGroup(self.groups[index].id).then(data => groupData(data))
         },
 
         watch: {

--- a/frontend/src/components/pages/organization_view.vue
+++ b/frontend/src/components/pages/organization_view.vue
@@ -6,6 +6,7 @@
         </div>
     </v-container>
     <v-container v-else fluid class="orgContainer px-md-10 py-4">
+        <Banner></Banner>
         <v-row wrap class="mt-0 py-4 px-md-15 fauxbar">
             <v-col cols=10 class="my-0 py-0" v-if="showFormError || showFormSuccess || group.state === 'deleted'">
                 <v-alert
@@ -146,6 +147,7 @@
     import MemberList from '../groups/MemberList'
     import Markdown from '../form/components/Markdown';
     import Edit from '../organizations/edit';
+    import Banner from '../banner/Banner'
 
     import {Analytics} from '../../services/analytics'
     const analyticsServ = new Analytics()
@@ -165,6 +167,7 @@
             MemberList: MemberList,
             Markdown: Markdown,
             Edit: Edit,
+            Banner: Banner
         },
         data () {
             return {

--- a/frontend/src/components/pages/organizations.vue
+++ b/frontend/src/components/pages/organizations.vue
@@ -6,6 +6,7 @@
         </div>
     </v-container>
     <v-container v-else fluid class="orgContainer px-md-11 py-4">
+        <Banner></Banner>
         <v-alert
             :value="showFormSuccess"
             class="fixed mr-md-1"
@@ -125,6 +126,7 @@
 <script>
     import OrgTree from '../organizations/OrgTree'
     import Edit from '../organizations/edit';
+    import Banner from '../banner/Banner'
 
     import {Analytics} from '../../services/analytics'
     const analyticsServ = new Analytics();
@@ -137,6 +139,7 @@
         components: {
             OrgTree: OrgTree,
             Edit: Edit,
+            Banner: Banner
         },
 
         data() {

--- a/frontend/src/components/pages/resource.vue
+++ b/frontend/src/components/pages/resource.vue
@@ -11,6 +11,7 @@
         </div>
     </v-container>
     <v-container v-else fluid grid-list-md class="main-area" :key="'resourceCRUD-'+redrawIndex">
+        <Banner></Banner>
         <v-row id="topOfResForm"></v-row>
         <v-row class="mt-0 py-4 wrap px-md-15 fauxbar">
             <v-col cols=10 class="my-0 py-0" v-if="showFormError || showFormSuccess || resource.state === 'deleted'">
@@ -206,6 +207,7 @@ import Preview from "../resources/preview";
 import JsonTable from "../resources/jsontable";
 import powButton from "../pow/powButton";
 import DeleteButton from '../DeleteButton';
+import Banner from '../banner/Banner'
 
 import Permissions from '@/mixins/permissions';
 
@@ -218,7 +220,8 @@ export default {
         Preview: Preview,
         JsonTable: JsonTable,
         powButton: powButton,
-        DeleteButton
+        DeleteButton,
+        Banner: Banner
     },
     data() {
         let schemaName = 'bcdc_dataset';

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -209,7 +209,10 @@ analyticsServ.ga().then( (gajson) => {
             label_colour: "#1A5A96",
             label_border: "#DDDDDD",
             error_text: "#D8292F",
-            home_label: "#888888"
+            home_label: "#888888",
+            banner_error: "#F2DEDE",
+            banner_warning: "#F9F1C6",
+            banner_info: "#D9EAF7"
           },
           light: {
             primary: '#003366',
@@ -233,7 +236,10 @@ analyticsServ.ga().then( (gajson) => {
             label_colour: "#1A5A96",
             label_border: "#DDDDDD",
             error_text: "#D8292F",
-            home_label: "#888888"
+            home_label: "#888888",
+            banner_error: "#F2DEDE",
+            banner_warning: "#F9F1C6",
+            banner_info: "#D9EAF7"
           }
         }
     }

--- a/frontend/src/services/apiConfig.js
+++ b/frontend/src/services/apiConfig.js
@@ -1,4 +1,4 @@
 export default 
 {
-    "timeout": 10000
+    "timeout": 15000
 }

--- a/frontend/src/store/modules/group.js
+++ b/frontend/src/store/modules/group.js
@@ -57,7 +57,7 @@ const actions = {
     },
 
     getGroups({ commit }) {
-        ckanServ.getGroupList().then((data) => {
+        return ckanServ.getGroupList().then((data) => {
             commit('setGroupList', { groups: data.result });
             commit('setSearchedGroups', { searchedGroups: data.result });
         });

--- a/pages/about.md
+++ b/pages/about.md
@@ -20,7 +20,5 @@ If you have questions about specific data, please review the Contact section and
 For technical support using the catalogue, please email [nrmenquiries@gov.bc.ca](mailto:nrmenquiries@gov.bc.ca).
 
 **Questions about the Catalogue:**  
-If you have general questions about the catalogue, please send us an email at [data@gov.bc.ca](mailto:data@gov.bc.ca).
-
-
+If you have general questions about the catalogue or wish to provide feedback, please open a ticket with the [Data Systems & Services request system](https://dpdd.atlassian.net/servicedesk/customer/portal/1). 
 

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -37,10 +37,9 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 ## RELEASE DETAILS AND DATES
 
-|**Deployment No.**|**Description**|**Beta**|**Production**|
+|**Deployment No.**|**Description**|**Test**|**Production**|
 |:---:|:---|:---:|:---:|
-|16|Added Configurable Information Banner (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|26-Jan-22||
-|15|Fix loading of groups page (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|26-Jan-22||
+|15|Fix loading of groups page, added configurable information banner, updated about page (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|26-Jan-22|14-Feb-22|
 |14|Enable snowplow analytics to be captured (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|07-Jan-22|26-Jan-22|
 |13|Update to enable exclamation marks and commas in URLs (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|08-Dec-21|12-Jan-22|
 |12|Updates deployed based on user feedback and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|23-Nov-21|30-Nov-21|
@@ -62,8 +61,10 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Issue**|**Tix No.**|
 |:---:|:---|:---:|
-|16|Added Configurable Information Banner| ([#705](https://github.com/bcgov/ckan-ui/pull/705))
-|15|Update GroupCards with new value| ([#688](https://github.com/bcgov/ckan-ui/pull/688))
+|15|Updated about page | ([#711](https://github.com/bcgov/ckan-ui/pull/711))
+|15|Added Configurable Information Banner | ([#705](https://github.com/bcgov/ckan-ui/pull/705))
+|15|Removed API calls from groups page | ([#702](https://github.com/bcgov/ckan-ui/pull/702))
+|15|Update GroupCards | ([#688](https://github.com/bcgov/ckan-ui/pull/688))
 |15|Loop group API calls| ([#670](https://github.com/bcgov/ckan-ui/pull/670))
 |14|Enable link click tracking| ([#662](https://github.com/bcgov/ckan-ui/pull/662), [#664](https://github.com/bcgov/ckan-ui/pull/664))
 |14|Add snowplow frontend script| ([#641](https://github.com/bcgov/ckan-ui/pull/641))

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -39,7 +39,8 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Description**|**Beta**|**Production**|
 |:---:|:---|:---:|:---:|
-|14|Enable snowplow analytics to be captured (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|07-Jan-22||
+|15|Fix loading of groups page (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|26-Jan-22||
+|14|Enable snowplow analytics to be captured (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|07-Jan-22|26-Jan-22|
 |13|Update to enable exclamation marks and commas in URLs (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|08-Dec-21|12-Jan-22|
 |12|Updates deployed based on user feedback and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|23-Nov-21|30-Nov-21|
 |11|Beta updates deployed based on user feedback and backlog prioritization (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|29-Oct-21|5-Nov-21|
@@ -60,6 +61,8 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Issue**|**Tix No.**|
 |:---:|:---|:---:|
+|15|Update GroupCards with new value| ([#688](https://github.com/bcgov/ckan-ui/pull/688))
+|15|Loop group API calls| ([#670](https://github.com/bcgov/ckan-ui/pull/670))
 |14|Enable link click tracking| ([#662](https://github.com/bcgov/ckan-ui/pull/662), [#664](https://github.com/bcgov/ckan-ui/pull/664))
 |14|Add snowplow frontend script| ([#641](https://github.com/bcgov/ckan-ui/pull/641))
 |13|Allow commas (,) in URL regex| ([#651](https://github.com/bcgov/ckan-ui/pull/651))

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -39,6 +39,7 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Description**|**Beta**|**Production**|
 |:---:|:---|:---:|:---:|
+|16|Added Configurable Information Banner (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|26-Jan-22||
 |15|Fix loading of groups page (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|26-Jan-22||
 |14|Enable snowplow analytics to be captured (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|07-Jan-22|26-Jan-22|
 |13|Update to enable exclamation marks and commas in URLs (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|08-Dec-21|12-Jan-22|
@@ -61,6 +62,7 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Issue**|**Tix No.**|
 |:---:|:---|:---:|
+|16|Added Configurable Information Banner| ([#705](https://github.com/bcgov/ckan-ui/pull/705))
 |15|Update GroupCards with new value| ([#688](https://github.com/bcgov/ckan-ui/pull/688))
 |15|Loop group API calls| ([#670](https://github.com/bcgov/ckan-ui/pull/670))
 |14|Enable link click tracking| ([#662](https://github.com/bcgov/ckan-ui/pull/662), [#664](https://github.com/bcgov/ckan-ui/pull/664))


### PR DESCRIPTION
Contents of release 2.1.4
- remove api call and dataset count from GroupCard, allowing groups page to load faster and without network errors
- increased api call timeout slightly to counteract complexity of group calls (stopgap to help pages load while we look at updating api call)
- added configurable information banner
- updated about page