### PR TITLE
Release/2.1.5

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckan-ui-bridge",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "private": true,
   "scripts": {
     "start": "NODE_ENV=prod node ./bin/www",

--- a/backend/routes/ckan/datasets.js
+++ b/backend/routes/ckan/datasets.js
@@ -12,17 +12,17 @@ var addRoutes = function(router){
                 body.dates = JSON.parse(body.dates);
             }
             
-            for (let i=0; i<body.dates.length; i++){
-                if (body.dates[i].type.toLowerCase() === "published"){
-                    body.record_publish_date = body.dates[i].date;
-                }else if (body.dates[i].type.toLowerCase() === "created"){
-                    body.record_create_date = body.dates[i].date;
-                }else if (body.dates[i].type.toLowerCase() === "archived"){
-                    body.record_archive_date = body.dates[i].date;
-                }else if (body.dates[i].type.toLowerCase() === "modified"){
-                    body.record_last_modified = body.dates[i].date;
-                }
-            }
+            // for (let i=0; i<body.dates.length; i++){
+            //     if (body.dates[i].type.toLowerCase() === "published"){
+            //         body.record_publish_date = body.dates[i].date;
+            //     }else if (body.dates[i].type.toLowerCase() === "created"){
+            //         body.record_create_date = body.dates[i].date;
+            //     }else if (body.dates[i].type.toLowerCase() === "archived"){
+            //         body.record_archive_date = body.dates[i].date;
+            //     }else if (body.dates[i].type.toLowerCase() === "modified"){
+            //         body.record_last_modified = body.dates[i].date;
+            //     }
+            // }
             if (convertBack){
                 body.dates = JSON.stringify(body.dates);
             }

--- a/frontend/src/components/dataset/ListCard.vue
+++ b/frontend/src/components/dataset/ListCard.vue
@@ -24,7 +24,8 @@
 
       <v-row wrap dense class="my-0 py-0">
         <!--<v-col cols=4 class="faded">{{$tc('Metadata Modified')}}: {{metaModDate}}</v-col>-->
-        <v-col cols=5 class="faded">{{$tc('First Published')}}: {{publishDate}}</v-col>
+        <v-col cols=5 class="faded" v-if="publishDate">{{$tc('First Published')}}: {{publishDate}}</v-col>
+        <v-col cols=5 class="faded" v-else>{{$tc('Unpublished')}}</v-col>
         <v-col cols=7 class="faded text-right"><strong>{{$tc('Data Types')}}: {{types}}</strong></v-col>
       </v-row>
 
@@ -116,13 +117,16 @@ export default {
         // }
 
         let formatDate = function(date){
-            let y = date.getFullYear();
-            let m = (date.getMonth() < 9 ? "0"+(date.getMonth()+1) : (date.getMonth()+1))
-            let d = (date.getDate() < 10 ? "0"+(date.getDate()) : (date.getDate()));
-            return y + "-" + m + "-" + d
+            if (date) {
+                let y = date.getFullYear();
+                let m = (date.getMonth() < 9 ? "0"+(date.getMonth()+1) : (date.getMonth()+1))
+                let d = (date.getDate() < 10 ? "0"+(date.getDate()) : (date.getDate()));
+                return y + "-" + m + "-" + d
+            }
+            return undefined
         }
 
-        let date = new Date(this.record.record_publish_date)
+        let date = this.record.record_publish_date ? new Date(this.record.record_publish_date) : undefined
         let pubDate = formatDate(date)
 
         let d2 = new Date(this.record.metadata_modified)

--- a/frontend/src/components/dataset/ListCard.vue
+++ b/frontend/src/components/dataset/ListCard.vue
@@ -122,7 +122,7 @@ export default {
             return y + "-" + m + "-" + d
         }
 
-        let date = new Date(this.record.metadata_created)
+        let date = new Date(this.record.record_publish_date)
         let pubDate = formatDate(date)
 
         let d2 = new Date(this.record.metadata_modified)

--- a/frontend/src/components/dataset/ListPage.vue
+++ b/frontend/src/components/dataset/ListPage.vue
@@ -110,7 +110,7 @@
               { value: "views_total desc", text: this.$tc("Popular") },
               { value: "name asc", text: this.$tc("Name") + " " + this.$tc("Ascending") },
               { value: "name desc", text: this.$tc("Name") + " " + this.$tc("Descending") },
-              { value: "metadata_created desc", text: this.$tc("Newest") }
+              { value: "record_publish_date desc", text: this.$tc("Newest") }
           ],
       }
     },
@@ -195,7 +195,7 @@
             // per bcgov#509
             let effectiveOrder = this.sortOrder;
             if ((!this.searchText || /^\s+$/.test(this.searchText)) && this.sortOrder.startsWith("score")) {
-                effectiveOrder = "metadata_created desc";
+                effectiveOrder = "record_publish_date desc";
             }
 
             let q = "?rows=" + this.rows+"&sort="+effectiveOrder+"&include_drafts=true&include_private=true&"

--- a/frontend/src/components/user/profile.vue
+++ b/frontend/src/components/user/profile.vue
@@ -4,8 +4,10 @@
             <v-col cols=12>
                 <v-card>
                     <v-card-text>
-                        <img :src="'https://www.gravatar.com/avatar/'+user.email_hash+'?s=190&d=identicon'" />
-                        <p>{{user.name}}</p>
+                        <v-avatar color="secondary" size="62" class="mb-5">
+                            <span class="white--text text-h5">{{ initials }}</span>
+                        </v-avatar>
+                        <p>{{user.display_name}}</p>
                         <p>Email: {{user.email}}</p>
                         <p>Api Key: {{user.apikey}}</p>
                     </v-card-text>
@@ -24,6 +26,12 @@
         },
         data() {
             return {};
+        },
+        computed: {
+            initials: function(){
+                return this.user && this.user.display_name ? 
+                    this.user.display_name.split(" ").map((n)=>n[0]).join("").toUpperCase() : "";
+            }
         },
         methods: {
         },

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -288,6 +288,7 @@ export default {
         "Scroll to Top": "Scroll to Top",
         "Permalink URL Copied to Clipboard": "Permalink URL Copied to Clipboard",
         "First Published": "First Published",
+        "Unpublished": "Unpublished",
         "Account Settings": "Account Settings",
         "Reset": "Reset",
         "Record Status": "Record Status",

--- a/frontend/src/i18n/fr.js
+++ b/frontend/src/i18n/fr.js
@@ -288,6 +288,7 @@ export default {
         "Scroll to Top": "Faire défiler vers le haut",
         "Permalink URL Copied to Clipboard": "URL du lien permanent copiée dans le presse-papiers",
         "First Published": "Première publication",
+        "Unpublished": "Non publié",
         "Account Settings": "Paramètres du compte",
         "Reset": "Réinitialiser",
         "Record Status": "Statut d'enregistrement",

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -39,6 +39,7 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Description**|**Test**|**Production**|
 |:---:|:---|:---:|:---:|
+|16|Fix record history lifecycle, update search order, remove gravitar (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|23-Feb-22||
 |15|Fix loading of groups page, added configurable information banner, updated about page (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|26-Jan-22|14-Feb-22|
 |14|Enable snowplow analytics to be captured (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|07-Jan-22|26-Jan-22|
 |13|Update to enable exclamation marks and commas in URLs (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|08-Dec-21|12-Jan-22|
@@ -61,6 +62,9 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Issue**|**Tix No.**|
 |:---:|:---|:---:|
+|16|Remove gravitar and replace with initials | ([#715](https://github.com/bcgov/ckan-ui/pull/715))
+|16|Change newest to use record_publish_date | ([#717](https://github.com/bcgov/ckan-ui/pull/717))
+|16|Fix resource lifecycle history to prevent overwrites | ([#716](https://github.com/bcgov/ckan-ui/pull/716))
 |15|Updated about page | ([#711](https://github.com/bcgov/ckan-ui/pull/711))
 |15|Added Configurable Information Banner | ([#705](https://github.com/bcgov/ckan-ui/pull/705))
 |15|Removed API calls from groups page | ([#702](https://github.com/bcgov/ckan-ui/pull/702))


### PR DESCRIPTION
Changes included in this release:
- removal of gravitar and replacement with initials
- "newest" search to use resource_publish_date instead of metadata_created
- fix to prevent resource lifecycle dates from overwriting other date fields