### PR TITLE
Release/2.1.6

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckan-ui-bridge",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "scripts": {
     "start": "NODE_ENV=prod node ./bin/www",

--- a/frontend/src/components/banner/Banner.vue
+++ b/frontend/src/components/banner/Banner.vue
@@ -14,7 +14,7 @@
 export default {
     data() {
       return {
-        message: 'We welcome your feedback! Help us improve your experience by taking our short 1 minute survey.',
+        message: '',
         action: 'https://form.simplesurvey.com/f/s.aspx?s=8d6269f2-2eb0-4dff-86af-09889bda98fe',
         actionText: 'Give Feedback',
         colour: 'banner_info' // RED: banner_error, YELLOW: banner_warning, BLUE: banner_info

--- a/frontend/src/components/form/components/CompositeRepeating.vue
+++ b/frontend/src/components/form/components/CompositeRepeating.vue
@@ -281,6 +281,7 @@ export default {
         },
         removeRecord: function(index) {
             this.model.splice(index,1);
+            this.$emit('edited', JSON.stringify(this.model));
         },
 
         modified: function(refName) {

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -39,7 +39,7 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Description**|**Test**|**Production**|
 |:---:|:---|:---:|:---:|
-|17|Remove survey banner, fix contact and lifecycle date deletions (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|14-March-22||
+|17|Remove survey banner, fix contact and lifecycle date deletions (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|14-March-22|17-March-22|
 |16|Fix record history lifecycle, update search order, remove gravitar (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|23-Feb-22|10-March-22|
 |15|Fix loading of groups page, added configurable information banner, updated about page (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|26-Jan-22|14-Feb-22|
 |14|Enable snowplow analytics to be captured (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|07-Jan-22|26-Jan-22|

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -39,6 +39,7 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Description**|**Test**|**Production**|
 |:---:|:---|:---:|:---:|
+|17|Remove survey banner, fix contact and lifecycle date deletions (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|14-March-22||
 |16|Fix record history lifecycle, update search order, remove gravitar (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|23-Feb-22|10-March-22|
 |15|Fix loading of groups page, added configurable information banner, updated about page (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|26-Jan-22|14-Feb-22|
 |14|Enable snowplow analytics to be captured (see [Fixed Issues](https://github.com/bcgov/ckan-ui/blob/master/pages/changelog.md#fixed-issues))|07-Jan-22|26-Jan-22|
@@ -62,6 +63,8 @@ This page is continually updated as changes are made to the BC Data Catalogue an
 
 |**Deployment No.**|**Issue**|**Tix No.**|
 |:---:|:---|:---:|
+|17|Remove survey banner | ([#728](https://github.com/bcgov/ckan-ui/pull/728))
+|17|Fix contact and lifecycle date deletion | ([#727](https://github.com/bcgov/ckan-ui/pull/727))
 |16|Remove gravitar and replace with initials | ([#715](https://github.com/bcgov/ckan-ui/pull/715))
 |16|Change newest to use record_publish_date | ([#717](https://github.com/bcgov/ckan-ui/pull/717))
 |16|Fix resource lifecycle history to prevent overwrites | ([#716](https://github.com/bcgov/ckan-ui/pull/716))


### PR DESCRIPTION
Changes in release 2.1.6:
- removal of survey banner
- fix allow deletion of contacts and lifecycle dates

Updated changelog with these fixes.