### PR TITLE
Fix user permissions error on /.npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ COPY backend/package*.json ./
 
 RUN npm ci --no-optional --production
 RUN mkdir /.config && chmod 777 /.config
+RUN mkdir /.npm
+RUN chgrp -R 0 /.npm && \
+    chmod -R g=u /.npm
 COPY backend/ ./
 EXPOSE 3000
 CMD [ "npm", "start" ]


### PR DESCRIPTION
Fix error with /.npm permissions
`npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /.npm
npm ERR! errno -13
npm ERR!
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR!
npm ERR! To permanently fix this problem, please run:
npm ERR! sudo chown -R <> "/.npm"`